### PR TITLE
Add installer and management scripts for SEI ANEEL automation

### DIFF
--- a/manage_processes.py
+++ b/manage_processes.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+import json
+import re
+import sys
+from pathlib import Path
+
+import gspread
+from oauth2client.service_account import ServiceAccountCredentials
+
+CONFIG_PATH = '/opt/sei-aneel/config/configs.json'
+
+
+def load_config(path=CONFIG_PATH):
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def connect_sheet(conf):
+    creds_file = conf['google_drive']['credentials_file']
+    sheet_name = conf['google_drive']['sheet_name']
+    worksheet_name = conf['google_drive']['worksheet_name']
+    scope = ['https://spreadsheets.google.com/feeds',
+             'https://www.googleapis.com/auth/drive']
+    creds = ServiceAccountCredentials.from_json_keyfile_name(creds_file, scope)
+    client = gspread.authorize(creds)
+    return client.open(sheet_name).worksheet(worksheet_name)
+
+
+def normalize(num: str) -> str:
+    return re.sub(r'\D', '', num or '')
+
+
+def add_process(sheet, numero):
+    sheet.append_row([numero, '', '', '', '', '', '', '', '', '', ''])
+    print(f'Processo {numero} adicionado.')
+
+
+def remove_process(sheet, numero):
+    col = sheet.col_values(1)
+    numero_norm = normalize(numero)
+    for idx, val in enumerate(col, start=1):
+        if normalize(val) == numero_norm:
+            sheet.delete_rows(idx)
+            print(f'Processo {numero} removido.')
+            return
+    print('Processo não encontrado.')
+
+
+def update_process(sheet, old, new):
+    col = sheet.col_values(1)
+    old_norm = normalize(old)
+    for idx, val in enumerate(col, start=1):
+        if normalize(val) == old_norm:
+            sheet.update_acell(f'A{idx}', new)
+            print(f'Processo {old} atualizado para {new}.')
+            return
+    print('Processo não encontrado.')
+
+
+def main():
+    if len(sys.argv) < 3:
+        print('Uso: manage_processes.py [add|remove|update] <número> [novo número]')
+        sys.exit(1)
+
+    action = sys.argv[1]
+    conf = load_config()
+    sheet = connect_sheet(conf)
+
+    if action == 'add':
+        add_process(sheet, sys.argv[2])
+    elif action == 'remove':
+        remove_process(sheet, sys.argv[2])
+    elif action == 'update':
+        if len(sys.argv) < 4:
+            print('Uso: manage_processes.py update <número_antigo> <número_novo>')
+            sys.exit(1)
+        update_process(sheet, sys.argv[2], sys.argv[3])
+    else:
+        print('Ação inválida. Use add, remove ou update.')
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+gspread
+oauth2client
+selenium
+python-2captcha
+pillow
+pytesseract
+colorama

--- a/sei-aneel.py
+++ b/sei-aneel.py
@@ -876,6 +876,8 @@ def main() -> List[Dict[str, str]]:
                        help='Modo passo-a-passo para debug')
     parser.add_argument('--max-processes', type=int,
                        help='Número máximo de processos a processar')
+    parser.add_argument('--processo', nargs='*',
+                       help='Números de processo específicos para consulta')
     args = parser.parse_args()
     
     # Inicializa interface interativa
@@ -977,11 +979,13 @@ def main() -> List[Dict[str, str]]:
     
     resultados = []
     try:
-        # Obtém processos da planilha
-        if ui:
-            print(f"\n{Fore.CYAN}📋 Obtendo lista de processos...")
-        
-        processos_brutos = planilha_handler.get_all_processos()
+        # Obtém processos
+        if args.processo:
+            processos_brutos = args.processo
+        else:
+            if ui:
+                print(f"\n{Fore.CYAN}📋 Obtendo lista de processos...")
+            processos_brutos = planilha_handler.get_all_processos()
         processos_validos = []
         
         for proc in processos_brutos:
@@ -1391,7 +1395,8 @@ def enviar_notificacao_email(mudancas: List[Dict], processos_falha: List[str],
         
         # Envia email
         server = smtplib.SMTP(smtp_config['server'], smtp_config.get('port', 587))
-        server.starttls()
+        if smtp_config.get('starttls', False):
+            server.starttls()
         server.login(smtp_config['user'], smtp_config['password'])
         
         text = msg.as_string()

--- a/sei-aneel.sh
+++ b/sei-aneel.sh
@@ -1,0 +1,266 @@
+#!/bin/bash
+SCRIPT_DIR="/opt/sei-aneel"
+CONFIG_DIR="$SCRIPT_DIR/config"
+CONFIG_FILE="$CONFIG_DIR/configs.json"
+LOG_DIR="$SCRIPT_DIR/logs"
+
+install_sei() {
+  read -p "Caminho do credentials.json: " CRED
+  read -p "Chave API 2captcha: " CAPTCHA
+  read -p "Servidor SMTP: " SMTP_SERVER
+  read -p "Porta SMTP [587]: " SMTP_PORT
+  SMTP_PORT=${SMTP_PORT:-587}
+  read -p "Usuário SMTP: " SMTP_USER
+  read -s -p "Senha SMTP: " SMTP_PASS; echo
+  read -p "Usar STARTTLS? (y/N): " SMTP_TLS
+  read -p "Emails destinatários (separados por vírgula): " EMAILS
+
+  sudo rm -rf "$SCRIPT_DIR"
+  sudo mkdir -p "$CONFIG_DIR" "$LOG_DIR"
+  sudo cp sei-aneel.py manage_processes.py test_connectivity.py requirements.txt "$SCRIPT_DIR/"
+  sudo cp "$CRED" "$CONFIG_DIR/credentials.json"
+  sudo chown -R "$USER":"$USER" "$SCRIPT_DIR"
+
+  sudo apt-get update
+  sudo apt-get install -y python3 python3-pip tesseract-ocr chromium-browser chromium-chromedriver
+  sudo pip3 install --break-system-packages -r "$SCRIPT_DIR/requirements.txt"
+
+  STARTTLS=false
+  [[ "${SMTP_TLS,,}" == "y" ]] && STARTTLS=true
+
+  IFS=',' read -ra ADDR <<< "$EMAILS"
+  EMAIL_JSON=$(printf '"%s",' "${ADDR[@]}")
+  EMAIL_JSON="${EMAIL_JSON%,}"
+
+  cat <<CFG > "$CONFIG_FILE"
+{
+  "smtp": {
+    "server": "$SMTP_SERVER",
+    "port": $SMTP_PORT,
+    "user": "$SMTP_USER",
+    "password": "$SMTP_PASS",
+    "starttls": $STARTTLS
+  },
+  "twocaptcha": {"api_key": "$CAPTCHA"},
+  "google_drive": {
+    "credentials_file": "$CONFIG_DIR/credentials.json",
+    "sheet_name": "Processos ANEEL",
+    "worksheet_name": "Processos"
+  },
+  "email": {"recipients": [$EMAIL_JSON]},
+  "paths": {
+    "tesseract": "/usr/bin/tesseract",
+    "chromedriver": "/usr/bin/chromedriver",
+    "chrome_binary": "/usr/bin/chromium-browser"
+  },
+  "execution": {
+    "captcha_max_tries": 5,
+    "max_retry_attempts": 5
+  },
+  "logging": {"level": "INFO"}
+}
+CFG
+
+  (crontab -l 2>/dev/null | grep -v 'sei-aneel.py'; echo "0 5,13,16 * * * /usr/bin/python3 $SCRIPT_DIR/sei-aneel.py >> $LOG_DIR/cron.log 2>&1") | crontab -
+  echo "Instalação concluída."
+}
+
+remove_sei() {
+  crontab -l 2>/dev/null | grep -v 'sei-aneel.py' | crontab -
+  sudo rm -rf "$SCRIPT_DIR"
+  echo "Remoção concluída."
+}
+
+config_twocaptcha() {
+  read -p "Nova chave 2captcha: " KEY
+  python3 - "$CONFIG_FILE" "$KEY" <<'PY'
+import json,sys
+path, key = sys.argv[1:3]
+with open(path) as f: data=json.load(f)
+data.setdefault('twocaptcha',{})['api_key']=key
+with open(path,'w') as f: json.dump(data,f,indent=2)
+PY
+}
+
+config_smtp() {
+  read -p "Servidor SMTP: " S
+  read -p "Porta [587]: " P; P=${P:-587}
+  read -p "Usuário: " U
+  read -s -p "Senha: " PW; echo
+  read -p "Usar STARTTLS? (y/N): " TLS
+  python3 - "$CONFIG_FILE" "$S" "$P" "$U" "$PW" "$TLS" <<'PY'
+import json,sys
+path,server,port,user,pw,tls=sys.argv[1:7]
+with open(path) as f: data=json.load(f)
+smtp=data.setdefault('smtp',{})
+smtp.update({'server':server,'port':int(port), 'user':user, 'password':pw, 'starttls': tls.lower()=='y'})
+with open(path,'w') as f: json.dump(data,f,indent=2)
+PY
+}
+
+config_google() {
+  read -p "Caminho credentials.json: " C
+  read -p "Nome da planilha [Processos ANEEL]: " SN; SN=${SN:-Processos ANEEL}
+  read -p "Nome da aba [Processos]: " WS; WS=${WS:-Processos}
+  sudo cp "$C" "$CONFIG_DIR/credentials.json"
+  python3 - "$CONFIG_FILE" "$CONFIG_DIR/credentials.json" "$SN" "$WS" <<'PY'
+import json,sys
+path,cred,sheet,ws=sys.argv[1:5]
+with open(path) as f: data=json.load(f)
+GD=data.setdefault('google_drive',{})
+GD.update({'credentials_file':cred,'sheet_name':sheet,'worksheet_name':ws})
+with open(path,'w') as f: json.dump(data,f,indent=2)
+PY
+}
+
+config_exec() {
+  read -p "Tentativas captcha [5]: " C; C=${C:-5}
+  read -p "Tentativas reprocessamento [5]: " R; R=${R:-5}
+  python3 - "$CONFIG_FILE" "$C" "$R" <<'PY'
+import json,sys
+path,c,r=sys.argv[1:4]
+with open(path) as f: data=json.load(f)
+ex=data.setdefault('execution',{})
+ex.update({'captcha_max_tries':int(c),'max_retry_attempts':int(r)})
+with open(path,'w') as f: json.dump(data,f,indent=2)
+PY
+}
+
+configure_sei() {
+  while true; do
+    echo "1) Configurar 2captcha"
+    echo "2) Configurar SMTP"
+    echo "3) Configurar Google Drive"
+    echo "4) Configurar tentativas"
+    echo "5) Voltar"
+    read -p "Opção: " op
+    case $op in
+      1) config_twocaptcha ;;
+      2) config_smtp ;;
+      3) config_google ;;
+      4) config_exec ;;
+      5) break ;;
+      *) echo "Opção inválida" ;;
+    esac
+  done
+}
+
+add_email() {
+  read -p "Email para adicionar: " EM
+  python3 - "$CONFIG_FILE" "$EM" <<'PY'
+import json,sys
+path,email=sys.argv[1:3]
+with open(path) as f: data=json.load(f)
+rec=data.setdefault('email',{}).setdefault('recipients',[])
+if email not in rec:
+    rec.append(email)
+with open(path,'w') as f: json.dump(data,f,indent=2)
+PY
+}
+
+remove_email() {
+  read -p "Email para remover: " EM
+  python3 - "$CONFIG_FILE" "$EM" <<'PY'
+import json,sys
+path,email=sys.argv[1:3]
+with open(path) as f: data=json.load(f)
+rec=data.setdefault('email',{}).setdefault('recipients',[])
+if email in rec:
+    rec.remove(email)
+with open(path,'w') as f: json.dump(data,f,indent=2)
+PY
+}
+
+list_emails() {
+  python3 - "$CONFIG_FILE" <<'PY'
+import json,sys
+path=sys.argv[1]
+with open(path) as f: data=json.load(f)
+for e in data.get('email',{}).get('recipients',[]):
+    print(e)
+PY
+}
+
+manage_emails() {
+  while true; do
+    echo "1) Listar"
+    echo "2) Adicionar"
+    echo "3) Remover"
+    echo "4) Voltar"
+    read -p "Opção: " op
+    case $op in
+      1) list_emails "$CONFIG_FILE" ;;
+      2) add_email ;;
+      3) remove_email ;;
+      4) break ;;
+      *) echo "Opção inválida" ;;
+    esac
+  done
+}
+
+manage_processes_menu() {
+  while true; do
+    echo "1) Adicionar processo"
+    echo "2) Remover processo"
+    echo "3) Atualizar processo"
+    echo "4) Voltar"
+    read -p "Opção: " op
+    case $op in
+      1) read -p "Número: " N; python3 "$SCRIPT_DIR/manage_processes.py" add "$N" ;;
+      2) read -p "Número: " N; python3 "$SCRIPT_DIR/manage_processes.py" remove "$N" ;;
+      3) read -p "Número antigo: " O; read -p "Número novo: " N; python3 "$SCRIPT_DIR/manage_processes.py" update "$O" "$N" ;;
+      4) break ;;
+      *) echo "Opção inválida" ;;
+    esac
+  done
+}
+
+force_run() {
+  log_file="$LOG_DIR/exec_$(date +%Y%m%d_%H%M%S).log"
+  read -p "Número(s) de processo específico(s) (enter para todos): " PROC
+  if [ -z "$PROC" ]; then
+    python3 "$SCRIPT_DIR/sei-aneel.py" | tee "$log_file"
+  else
+    python3 "$SCRIPT_DIR/sei-aneel.py" --processo $PROC | tee "$log_file"
+  fi
+}
+
+schedule_cron() {
+  read -p "Dias da semana [*]: " D; D=${D:-*}
+  read -p "Horas (ex: 5,13,16): " H
+  (crontab -l 2>/dev/null | grep -v 'sei-aneel.py'; echo "0 $H * * $D /usr/bin/python3 $SCRIPT_DIR/sei-aneel.py >> $LOG_DIR/cron.log 2>&1") | crontab -
+  echo "Cron agendado."
+}
+
+test_connectivity() {
+  python3 "$SCRIPT_DIR/test_connectivity.py"
+}
+
+menu() {
+  while true; do
+    echo "1) Instalar"
+    echo "2) Remover"
+    echo "3) Configurar"
+    echo "4) Gerenciar emails"
+    echo "5) Gerenciar processos"
+    echo "6) Testar conectividade"
+    echo "7) Executar forçado"
+    echo "8) Agendar via cron"
+    echo "9) Sair"
+    read -p "Opção: " OP
+    case $OP in
+      1) install_sei ;;
+      2) remove_sei ;;
+      3) configure_sei ;;
+      4) manage_emails ;;
+      5) manage_processes_menu ;;
+      6) test_connectivity ;;
+      7) force_run ;;
+      8) schedule_cron ;;
+      9) exit 0 ;;
+      *) echo "Opção inválida" ;;
+    esac
+  done
+}
+
+menu

--- a/test_connectivity.py
+++ b/test_connectivity.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+import json
+import smtplib
+import urllib.request
+
+import gspread
+from oauth2client.service_account import ServiceAccountCredentials
+
+CONFIG_PATH = '/opt/sei-aneel/config/configs.json'
+
+
+def load_config():
+    with open(CONFIG_PATH, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def test_twocaptcha(api_key):
+    try:
+        url = f'https://2captcha.com/res.php?key={api_key}&action=getbalance'
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            resp.read()
+        print('2captcha: OK')
+    except Exception as e:
+        print(f'2captcha: {e}')
+
+
+def test_smtp(conf):
+    try:
+        server = smtplib.SMTP(conf['server'], conf.get('port', 587), timeout=10)
+        if conf.get('starttls', False):
+            server.starttls()
+        server.login(conf['user'], conf['password'])
+        server.quit()
+        print('SMTP: OK')
+    except Exception as e:
+        print(f'SMTP: {e}')
+
+
+def test_sheet(conf):
+    try:
+        scope = ['https://spreadsheets.google.com/feeds',
+                 'https://www.googleapis.com/auth/drive']
+        creds = ServiceAccountCredentials.from_json_keyfile_name(
+            conf['google_drive']['credentials_file'], scope)
+        client = gspread.authorize(creds)
+        client.open(conf['google_drive']['sheet_name']).worksheet(
+            conf['google_drive']['worksheet_name'])
+        print('Google Sheets: OK')
+    except Exception as e:
+        print(f'Google Sheets: {e}')
+
+
+def main():
+    conf = load_config()
+    test_twocaptcha(conf.get('twocaptcha', {}).get('api_key', ''))
+    test_smtp(conf.get('smtp', {}))
+    test_sheet(conf)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Provide `sei-aneel.sh` installer with cron scheduling, configuration prompts and management menus
- Support editing SEI process entries and email recipients via new helper scripts
- Allow running specific process numbers and optional STARTTLS in SMTP from `sei-aneel.py`

## Testing
- `python -m py_compile sei-aneel.py manage_processes.py test_connectivity.py`
- `bash -n sei-aneel.sh`
- `sudo apt-get update` *(failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6895f9b0a5c0832b8b98fce6433a8b0f