### PR TITLE
Centralize configuration loading

### DIFF
--- a/config_loader.py
+++ b/config_loader.py
@@ -1,0 +1,18 @@
+import json
+import os
+from pathlib import Path
+
+DEFAULT_CONFIG_PATH = os.environ.get(
+    "SEI_ANEEL_CONFIG",
+    "/opt/sei-aneel/config/configs.json"
+)
+
+def load_config(path: str = None):
+    config_path = path or DEFAULT_CONFIG_PATH
+    with open(config_path, 'r', encoding='utf-8') as f:
+        config = json.load(f)
+
+    smtp = config.setdefault('smtp', {})
+    smtp.setdefault('port', 587)
+    smtp.setdefault('starttls', False)
+    return config

--- a/manage_processes.py
+++ b/manage_processes.py
@@ -7,12 +7,7 @@ from pathlib import Path
 import gspread
 from oauth2client.service_account import ServiceAccountCredentials
 
-CONFIG_PATH = '/opt/sei-aneel/config/configs.json'
-
-
-def load_config(path=CONFIG_PATH):
-    with open(path, 'r', encoding='utf-8') as f:
-        return json.load(f)
+from config_loader import load_config
 
 
 def connect_sheet(conf):

--- a/pauta_aneel/pauta_aneel.py
+++ b/pauta_aneel/pauta_aneel.py
@@ -14,6 +14,7 @@ import tempfile
 import subprocess
 from urllib.parse import urljoin
 import hashlib
+from config_loader import load_config
 
 # Diretório de dados e arquivos de log
 DATA_DIR = os.environ.get("PAUTA_DATA_DIR", os.path.join(os.path.expanduser("~"), ".pauta_aneel"))
@@ -34,12 +35,14 @@ def registrar_log(mensagem):
 registrar_log("Início da execução")
 # ================================================
 
-# Configurações de e-mail
-SMTP_SERVER = os.environ.get("SMTP_SERVER", "smtp.hscl.adv.br")
-SMTP_PORT = int(os.environ.get("SMTP_PORT", "587"))
-SMTP_USER = os.environ.get("SMTP_USER", "ro-dou@hscl.adv.br")
-SMTP_PASSWORD = os.environ.get("SMTP_PASSWORD", "Aasn1989")
-EMAIL_TO = os.environ.get("EMAIL_TO", "asamia@isacteep.com.br,ary@hscl.adv.br")
+# Configurações de e-mail a partir de arquivo de configuração
+CONFIG = load_config()
+SMTP_CONF = CONFIG.get("smtp", {})
+SMTP_SERVER = SMTP_CONF.get("server", "")
+SMTP_PORT = SMTP_CONF.get("port", 587)
+SMTP_USER = SMTP_CONF.get("user", "")
+SMTP_PASSWORD = SMTP_CONF.get("password", "")
+EMAIL_TO = ",".join(CONFIG.get("email", {}).get("recipients", []))
 
 BASE_URL = "https://www2.aneel.gov.br/aplicacoes_liferay/noticias_area/?idAreaNoticia=425"
 SITE_PREFIX = "https://www2.aneel.gov.br"

--- a/sei-aneel.py
+++ b/sei-aneel.py
@@ -19,6 +19,7 @@ import colorama
 from colorama import Fore, Back, Style
 import threading
 import signal
+from config_loader import DEFAULT_CONFIG_PATH
 
 # Inicializa colorama para Windows
 colorama.init(autoreset=True)
@@ -201,10 +202,7 @@ class ConfigManager:
     
     def __init__(self, config_path: str = None):
         if config_path is None:
-            if platform.system() == "Windows":
-                config_path = os.path.join(os.getcwd(), "config", "configs.json")
-            else:
-                config_path = "/opt/sei-aneel/config/configs.json"
+            config_path = DEFAULT_CONFIG_PATH
         
         self.config_path = config_path
         self.config = self.load_config()
@@ -213,7 +211,11 @@ class ConfigManager:
         """Carrega configurações do arquivo JSON"""
         try:
             with open(self.config_path, 'r', encoding='utf-8') as f:
-                return json.load(f)
+                config = json.load(f)
+            smtp = config.setdefault('smtp', {})
+            smtp.setdefault('port', 587)
+            smtp.setdefault('starttls', False)
+            return config
         except FileNotFoundError:
             raise FileNotFoundError(f"Arquivo de configuração não encontrado: {self.config_path}")
         except json.JSONDecodeError as e:

--- a/sei-aneel.sh
+++ b/sei-aneel.sh
@@ -13,6 +13,8 @@ CONFIG_FILE="$CONFIG_DIR/configs.json"
 LOG_DIR="$SCRIPT_DIR/logs"
 REPO_URL="https://github.com/aryabdo/sei-aneel.git"
 
+export SEI_ANEEL_CONFIG="$CONFIG_FILE"
+
 # Diretórios para módulos adicionais
 PAUTA_DIR="/opt/pauta-aneel"
 PAUTA_CONFIG="$PAUTA_DIR/config.env"

--- a/sorteio_aneel/sorteio_aneel.py
+++ b/sorteio_aneel/sorteio_aneel.py
@@ -13,6 +13,7 @@ import unicodedata
 import tempfile
 import subprocess
 import json
+from config_loader import load_config
 
 # Diretório de dados e arquivos de log
 DATA_DIR = os.environ.get("SORTEIO_DATA_DIR", os.path.join(os.path.expanduser("~"), ".sorteio_aneel"))
@@ -32,15 +33,14 @@ def registrar_log(mensagem):
 registrar_log("Início da execução")
 # ================================================
 
-# Configurações de e-mail
-SMTP_SERVER = os.environ.get("SMTP_SERVER", "smtp.hscl.adv.br")
-SMTP_PORT = int(os.environ.get("SMTP_PORT", "587"))
-SMTP_USER = os.environ.get("SMTP_USER", "ro-dou@hscl.adv.br")
-SMTP_PASSWORD = os.environ.get("SMTP_PASSWORD", "Aasn1989")
-EMAIL_TO = os.environ.get(
-    "EMAIL_TO",
-    "ARY@HSCL.ADV.BR,asamia@isacteep.com.br"
-)
+# Configurações de e-mail a partir de arquivo de configuração
+CONFIG = load_config()
+SMTP_CONF = CONFIG.get("smtp", {})
+SMTP_SERVER = SMTP_CONF.get("server", "")
+SMTP_PORT = SMTP_CONF.get("port", 587)
+SMTP_USER = SMTP_CONF.get("user", "")
+SMTP_PASSWORD = SMTP_CONF.get("password", "")
+EMAIL_TO = ",".join(CONFIG.get("email", {}).get("recipients", []))
 
 BASE_URL = "https://www2.aneel.gov.br/aplicacoes_liferay/noticias_area/?idAreaNoticia=424"
 SITE_PREFIX = "https://www2.aneel.gov.br"

--- a/test_connectivity.py
+++ b/test_connectivity.py
@@ -2,16 +2,13 @@
 import json
 import smtplib
 import urllib.request
+import json
+import smtplib
 
 import gspread
 from oauth2client.service_account import ServiceAccountCredentials
 
-CONFIG_PATH = '/opt/sei-aneel/config/configs.json'
-
-
-def load_config():
-    with open(CONFIG_PATH, 'r', encoding='utf-8') as f:
-        return json.load(f)
+from config_loader import load_config
 
 
 def test_twocaptcha(api_key):


### PR DESCRIPTION
## Summary
- add shared `config_loader` for unified settings with default SMTP values
- update pauta and sorteio utilities to read email settings from shared config
- adjust core scripts and shell launcher to respect `SEI_ANEEL_CONFIG`

## Testing
- `python -m py_compile config_loader.py pauta_aneel/pauta_aneel.py sorteio_aneel/sorteio_aneel.py sei-aneel.py test_connectivity.py manage_processes.py`
- `python test_connectivity.py` *(fails: 2captcha <urlopen error Tunnel connection failed: 403 Forbidden>; SMTP [Errno -2] Name or service not known; Google Sheets [Errno 2] No such file or directory: 'credentials.json')*


------
https://chatgpt.com/codex/tasks/task_e_6896775d029c832b8ab05210d4858217