### PR TITLE
Add configuration menus and backup utilities

### DIFF
--- a/backup_manager.py
+++ b/backup_manager.py
@@ -1,0 +1,70 @@
+import argparse
+import os
+from datetime import datetime
+from pathlib import Path
+import zipfile
+
+from config_loader import load_config, DEFAULT_CONFIG_PATH
+
+def _zip_dirs(base_dir: Path, target_dirs: list[Path]) -> Path:
+    base_dir = base_dir.resolve()
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    backup_dir = base_dir / 'backups'
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    backup_file = backup_dir / f'sei_aneel_backup_{timestamp}.zip'
+    with zipfile.ZipFile(backup_file, 'w', zipfile.ZIP_DEFLATED) as zf:
+        for d in target_dirs:
+            if d.exists():
+                for root, _, files in os.walk(d):
+                    for f in files:
+                        full_path = Path(root) / f
+                        zf.write(full_path, full_path.relative_to(base_dir))
+    return backup_file
+
+def backup_local(config_path: str = DEFAULT_CONFIG_PATH) -> Path:
+    cfg_path = Path(config_path)
+    base_dir = cfg_path.parent.parent
+    target_dirs = [base_dir / 'config', base_dir / 'logs']
+    backup_file = _zip_dirs(base_dir, target_dirs)
+    print(f'Backup local criado em {backup_file}')
+    return backup_file
+
+def upload_to_drive(file_path: Path, credentials_file: str):
+    try:
+        from google.oauth2.service_account import Credentials
+        from googleapiclient.discovery import build
+        from googleapiclient.http import MediaFileUpload
+    except Exception as e:
+        print(f'Bibliotecas do Google não disponíveis: {e}')
+        return
+
+    scopes = ['https://www.googleapis.com/auth/drive.file']
+    creds = Credentials.from_service_account_file(credentials_file, scopes=scopes)
+    service = build('drive', 'v3', credentials=creds)
+    file_metadata = {'name': file_path.name}
+    media = MediaFileUpload(str(file_path), resumable=False)
+    service.files().create(body=file_metadata, media_body=media, fields='id').execute()
+    print('Backup enviado ao Google Drive.')
+
+def backup_gdrive(config_path: str = DEFAULT_CONFIG_PATH) -> None:
+    config = load_config(config_path)
+    creds_file = config.get('google_drive', {}).get('credentials_file')
+    if not creds_file:
+        print('Arquivo de credenciais do Google Drive não definido.')
+        return
+    backup_file = backup_local(config_path)
+    upload_to_drive(backup_file, creds_file)
+
+def main():
+    parser = argparse.ArgumentParser(description='Gerenciador de backups SEI ANEEL')
+    parser.add_argument('mode', choices=['local', 'gdrive'], help='Tipo de backup a executar')
+    parser.add_argument('--config', default=DEFAULT_CONFIG_PATH, help='Caminho para configs.json')
+    args = parser.parse_args()
+
+    if args.mode == 'local':
+        backup_local(args.config)
+    else:
+        backup_gdrive(args.config)
+
+if __name__ == '__main__':
+    main()

--- a/config_loader.py
+++ b/config_loader.py
@@ -1,0 +1,18 @@
+import json
+import os
+from pathlib import Path
+
+DEFAULT_CONFIG_PATH = os.environ.get(
+    "SEI_ANEEL_CONFIG",
+    "/opt/sei-aneel/config/configs.json"
+)
+
+def load_config(path: str = None):
+    config_path = path or DEFAULT_CONFIG_PATH
+    with open(config_path, 'r', encoding='utf-8') as f:
+        config = json.load(f)
+
+    smtp = config.setdefault('smtp', {})
+    smtp.setdefault('port', 587)
+    smtp.setdefault('starttls', False)
+    return config

--- a/manage_processes.py
+++ b/manage_processes.py
@@ -7,12 +7,7 @@ from pathlib import Path
 import gspread
 from oauth2client.service_account import ServiceAccountCredentials
 
-CONFIG_PATH = '/opt/sei-aneel/config/configs.json'
-
-
-def load_config(path=CONFIG_PATH):
-    with open(path, 'r', encoding='utf-8') as f:
-        return json.load(f)
+from config_loader import load_config
 
 
 def connect_sheet(conf):

--- a/pauta_aneel/pauta_aneel.py
+++ b/pauta_aneel/pauta_aneel.py
@@ -14,6 +14,7 @@ import tempfile
 import subprocess
 from urllib.parse import urljoin
 import hashlib
+from config_loader import load_config
 
 # Diretório de dados e arquivos de log
 DATA_DIR = os.environ.get("PAUTA_DATA_DIR", os.path.join(os.path.expanduser("~"), ".pauta_aneel"))
@@ -34,12 +35,14 @@ def registrar_log(mensagem):
 registrar_log("Início da execução")
 # ================================================
 
-# Configurações de e-mail
-SMTP_SERVER = os.environ.get("SMTP_SERVER", "smtp.hscl.adv.br")
-SMTP_PORT = int(os.environ.get("SMTP_PORT", "587"))
-SMTP_USER = os.environ.get("SMTP_USER", "ro-dou@hscl.adv.br")
-SMTP_PASSWORD = os.environ.get("SMTP_PASSWORD", "Aasn1989")
-EMAIL_TO = os.environ.get("EMAIL_TO", "asamia@isacteep.com.br,ary@hscl.adv.br")
+# Configurações de e-mail a partir de arquivo de configuração
+CONFIG = load_config()
+SMTP_CONF = CONFIG.get("smtp", {})
+SMTP_SERVER = SMTP_CONF.get("server", "")
+SMTP_PORT = SMTP_CONF.get("port", 587)
+SMTP_USER = SMTP_CONF.get("user", "")
+SMTP_PASSWORD = SMTP_CONF.get("password", "")
+EMAIL_TO = ",".join(CONFIG.get("email", {}).get("recipients", []))
 
 BASE_URL = "https://www2.aneel.gov.br/aplicacoes_liferay/noticias_area/?idAreaNoticia=425"
 SITE_PREFIX = "https://www2.aneel.gov.br"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytesseract
 colorama
 requests
 beautifulsoup4
+google-api-python-client

--- a/sei-aneel.py
+++ b/sei-aneel.py
@@ -19,6 +19,7 @@ import colorama
 from colorama import Fore, Back, Style
 import threading
 import signal
+from config_loader import DEFAULT_CONFIG_PATH
 
 # Inicializa colorama para Windows
 colorama.init(autoreset=True)
@@ -201,10 +202,7 @@ class ConfigManager:
     
     def __init__(self, config_path: str = None):
         if config_path is None:
-            if platform.system() == "Windows":
-                config_path = os.path.join(os.getcwd(), "config", "configs.json")
-            else:
-                config_path = "/opt/sei-aneel/config/configs.json"
+            config_path = DEFAULT_CONFIG_PATH
         
         self.config_path = config_path
         self.config = self.load_config()
@@ -213,7 +211,11 @@ class ConfigManager:
         """Carrega configurações do arquivo JSON"""
         try:
             with open(self.config_path, 'r', encoding='utf-8') as f:
-                return json.load(f)
+                config = json.load(f)
+            smtp = config.setdefault('smtp', {})
+            smtp.setdefault('port', 587)
+            smtp.setdefault('starttls', False)
+            return config
         except FileNotFoundError:
             raise FileNotFoundError(f"Arquivo de configuração não encontrado: {self.config_path}")
         except json.JSONDecodeError as e:

--- a/sei-aneel.sh
+++ b/sei-aneel.sh
@@ -13,6 +13,8 @@ CONFIG_FILE="$CONFIG_DIR/configs.json"
 LOG_DIR="$SCRIPT_DIR/logs"
 REPO_URL="https://github.com/aryabdo/sei-aneel.git"
 
+export SEI_ANEEL_CONFIG="$CONFIG_FILE"
+
 # Diretórios para módulos adicionais
 PAUTA_DIR="/opt/pauta-aneel"
 PAUTA_CONFIG="$PAUTA_DIR/config.env"
@@ -233,14 +235,15 @@ remove_cron_pauta() {
 
 cron_menu_pauta() {
   while true; do
-    echo -e "${CYAN}1) Agendar/Alterar cron${NC}"
-    echo -e "${CYAN}2) Remover cron${NC}"
-    echo -e "${CYAN}3) Voltar${NC}"
+    echo -e "${CYAN}1) Incluir/Editar agendamento${NC}"
+    echo -e "${CYAN}2) Apagar registro${NC}"
+    echo -e "${CYAN}3) Apagar todos agendamentos${NC}"
+    echo -e "${CYAN}4) Voltar${NC}"
     read -p $'\e[33mOpção: \e[0m' op
     case $op in
       1) schedule_cron_pauta ;;
       2) remove_cron_pauta ;;
-      3) break ;;
+      4) break ;;
       *) echo -e "${RED}Opção inválida${NC}" ;;
     esac
   done
@@ -390,14 +393,15 @@ remove_cron_sorteio() {
 
 cron_menu_sorteio() {
   while true; do
-    echo -e "${CYAN}1) Agendar/Alterar cron${NC}"
-    echo -e "${CYAN}2) Remover cron${NC}"
-    echo -e "${CYAN}3) Voltar${NC}"
+    echo -e "${CYAN}1) Incluir/Editar agendamento${NC}"
+    echo -e "${CYAN}2) Apagar registro${NC}"
+    echo -e "${CYAN}3) Apagar todos agendamentos${NC}"
+    echo -e "${CYAN}4) Voltar${NC}"
     read -p $'\e[33mOpção: \e[0m' op
     case $op in
       1) schedule_cron_sorteio ;;
       2) remove_cron_sorteio ;;
-      3) break ;;
+      4) break ;;
       *) echo -e "${RED}Opção inválida${NC}" ;;
     esac
   done
@@ -474,14 +478,16 @@ configure_sei() {
     echo -e "${CYAN}2) Configurar SMTP${NC}"
     echo -e "${CYAN}3) Configurar Google Drive${NC}"
     echo -e "${CYAN}4) Configurar tentativas${NC}"
-    echo -e "${CYAN}5) Voltar${NC}"
+    echo -e "${CYAN}5) Gerenciar emails${NC}"
+    echo -e "${CYAN}6) Voltar${NC}"
     read -p $'\e[33mOpção: \e[0m' op
     case $op in
       1) config_twocaptcha ;;
       2) config_smtp ;;
       3) config_google ;;
       4) config_exec ;;
-      5) break ;;
+      5) manage_emails ;;
+      6) break ;;
       *) echo -e "${RED}Opção inválida${NC}" ;;
     esac
   done
@@ -587,16 +593,23 @@ remove_cron() {
   echo -e "${GREEN}Cron removido.${NC}"
 }
 
+clear_all_cron() {
+  crontab -r
+  echo -e "${GREEN}Todos agendamentos removidos.${NC}"
+}
+
 cron_menu() {
   while true; do
-    echo -e "${CYAN}1) Agendar/Alterar cron${NC}"
-    echo -e "${CYAN}2) Remover cron${NC}"
-    echo -e "${CYAN}3) Voltar${NC}"
+    echo -e "${CYAN}1) Incluir/Editar agendamento${NC}"
+    echo -e "${CYAN}2) Apagar registro${NC}"
+    echo -e "${CYAN}3) Apagar todos agendamentos${NC}"
+    echo -e "${CYAN}4) Voltar${NC}"
     read -p $'\e[33mOpção: \e[0m' op
     case $op in
       1) schedule_cron ;;
       2) remove_cron ;;
-      3) break ;;
+      3) clear_all_cron ;;
+      4) break ;;
       *) echo -e "${RED}Opção inválida${NC}" ;;
     esac
   done
@@ -614,6 +627,41 @@ view_logs() {
 
 test_connectivity() {
   python3 "$SCRIPT_DIR/test_connectivity.py"
+}
+
+
+backup_menu() {
+  while true; do
+    echo -e "${CYAN}1) Backup local${NC}"
+    echo -e "${CYAN}2) Backup Google Drive${NC}"
+    echo -e "${CYAN}3) Voltar${NC}"
+    read -p $'\e[33mOpção: \e[0m' op
+    case $op in
+      1) python3 "$SCRIPT_DIR/backup_manager.py" local ;;
+      2) python3 "$SCRIPT_DIR/backup_manager.py" gdrive ;;
+      3) break ;;
+      *) echo -e "${RED}Opção inválida${NC}" ;;
+    esac
+  done
+}
+
+config_menu() {
+  while true; do
+    echo -e "${CYAN}1) Configurações de conexão${NC}"
+    echo -e "${CYAN}2) Teste de conectividade${NC}"
+    echo -e "${CYAN}3) Configurações CRON${NC}"
+    echo -e "${CYAN}4) Backup${NC}"
+    echo -e "${CYAN}5) Voltar${NC}"
+    read -p $'\e[33mOpção: \e[0m' op
+    case $op in
+      1) configure_sei ;;
+      2) test_connectivity ;;
+      3) cron_menu ;;
+      4) backup_menu ;;
+      5) break ;;
+      *) echo -e "${RED}Opção inválida${NC}" ;;
+    esac
+  done
 }
 
 sei_menu() {
@@ -713,13 +761,15 @@ main_menu() {
     echo -e "${CYAN}1) SEI ANEEL${NC}"
     echo -e "${CYAN}2) Pauta ANEEL${NC}"
     echo -e "${CYAN}3) Sorteio ANEEL${NC}"
-    echo -e "${CYAN}4) Sair${NC}"
+    echo -e "${CYAN}4) Configurações${NC}"
+    echo -e "${CYAN}5) Sair${NC}"
     read -p $'\e[33mOpção: \e[0m' OP
     case $OP in
       1) sei_menu ;;
       2) pauta_menu ;;
       3) sorteio_menu ;;
-      4) exit 0 ;;
+      4) config_menu ;;
+      5) exit 0 ;;
       *) echo -e "${RED}Opção inválida${NC}" ;;
     esac
   done

--- a/sorteio_aneel/sorteio_aneel.py
+++ b/sorteio_aneel/sorteio_aneel.py
@@ -13,6 +13,7 @@ import unicodedata
 import tempfile
 import subprocess
 import json
+from config_loader import load_config
 
 # Diretório de dados e arquivos de log
 DATA_DIR = os.environ.get("SORTEIO_DATA_DIR", os.path.join(os.path.expanduser("~"), ".sorteio_aneel"))
@@ -32,15 +33,14 @@ def registrar_log(mensagem):
 registrar_log("Início da execução")
 # ================================================
 
-# Configurações de e-mail
-SMTP_SERVER = os.environ.get("SMTP_SERVER", "smtp.hscl.adv.br")
-SMTP_PORT = int(os.environ.get("SMTP_PORT", "587"))
-SMTP_USER = os.environ.get("SMTP_USER", "ro-dou@hscl.adv.br")
-SMTP_PASSWORD = os.environ.get("SMTP_PASSWORD", "Aasn1989")
-EMAIL_TO = os.environ.get(
-    "EMAIL_TO",
-    "ARY@HSCL.ADV.BR,asamia@isacteep.com.br"
-)
+# Configurações de e-mail a partir de arquivo de configuração
+CONFIG = load_config()
+SMTP_CONF = CONFIG.get("smtp", {})
+SMTP_SERVER = SMTP_CONF.get("server", "")
+SMTP_PORT = SMTP_CONF.get("port", 587)
+SMTP_USER = SMTP_CONF.get("user", "")
+SMTP_PASSWORD = SMTP_CONF.get("password", "")
+EMAIL_TO = ",".join(CONFIG.get("email", {}).get("recipients", []))
 
 BASE_URL = "https://www2.aneel.gov.br/aplicacoes_liferay/noticias_area/?idAreaNoticia=424"
 SITE_PREFIX = "https://www2.aneel.gov.br"

--- a/test_connectivity.py
+++ b/test_connectivity.py
@@ -2,16 +2,13 @@
 import json
 import smtplib
 import urllib.request
+import json
+import smtplib
 
 import gspread
 from oauth2client.service_account import ServiceAccountCredentials
 
-CONFIG_PATH = '/opt/sei-aneel/config/configs.json'
-
-
-def load_config():
-    with open(CONFIG_PATH, 'r', encoding='utf-8') as f:
-        return json.load(f)
+from config_loader import load_config
 
 
 def test_twocaptcha(api_key):


### PR DESCRIPTION
## Summary
- add backup manager for local and Google Drive archives
- extend shell menu with configuration, cron, and backup options
- include google API client dependency

## Testing
- `python -m py_compile config_loader.py pauta_aneel/pauta_aneel.py sorteio_aneel/sorteio_aneel.py sei-aneel.py test_connectivity.py manage_processes.py backup_manager.py`
- `python test_connectivity.py` *(fails: No such file or directory: '/opt/sei-aneel/config/configs.json')*
- `python backup_manager.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6896775d029c832b8ab05210d4858217