### PR TITLE
Centralize configuration and remove module-specific setup

### DIFF
--- a/config/configs.example.json
+++ b/config/configs.example.json
@@ -1,0 +1,58 @@
+{
+  "smtp": {
+    "server": "smtp.exemplo.com",
+    "port": 587,
+    "user": "usuario",
+    "password": "senha",
+    "starttls": false
+  },
+  "twocaptcha": {
+    "api_key": "SUA_CHAVE_2CAPTCHA"
+  },
+  "google_drive": {
+    "credentials_file": "/caminho/para/credentials.json",
+    "sheet_name": "Processos ANEEL",
+    "worksheet_name": "Processos"
+  },
+  "email": {
+    "recipients": ["destinatario@exemplo.com"]
+  },
+  "keywords": {
+    "pauta": [
+      "consulta publica",
+      "tomada de subsidio",
+      "consulta externa",
+      "audiencia publica",
+      "leilao",
+      "isa energia",
+      "cteep",
+      "companhia de transmissao de energia eletrica paulista",
+      "interligacao eletrica"
+    ],
+    "sorteio": [
+      "consulta publica",
+      "reajuste tarifario",
+      "rbse",
+      "tomada de subsidio",
+      "consulta externa",
+      "audiencia publica",
+      "leilao",
+      "isa energia",
+      "cteep",
+      "companhia de transmissao de energia eletrica paulista",
+      "interligacao eletrica"
+    ]
+  },
+  "paths": {
+    "tesseract": "/usr/bin/tesseract",
+    "chromedriver": "/usr/bin/chromedriver",
+    "chrome_binary": "/usr/bin/chromium-browser"
+  },
+  "execution": {
+    "captcha_max_tries": 5,
+    "max_retry_attempts": 5
+  },
+  "logging": {
+    "level": "INFO"
+  }
+}

--- a/config_loader.py
+++ b/config_loader.py
@@ -1,18 +1,77 @@
+"""Utility helpers to load configuration for all modules.
+
+The project relies on a single JSON file to store every piece of
+configuration.  This module exposes a ``load_config`` function used by all
+Python scripts.  Defaults for optional values are applied here so the rest
+of the code base can assume the presence of the expected keys.
+"""
+
 import json
 import os
 from pathlib import Path
+from typing import Any, Dict
 
+# Default location of the configuration file.  It can be overridden through
+# the ``SEI_ANEEL_CONFIG`` environment variable which is also exported by the
+# shell installer scripts.
 DEFAULT_CONFIG_PATH = os.environ.get(
     "SEI_ANEEL_CONFIG",
-    "/opt/sei-aneel/config/configs.json"
+    "/opt/sei-aneel/config/configs.json",
 )
 
-def load_config(path: str = None):
+# Fallback keyword lists used by ``pauta_aneel`` and ``sorteio_aneel`` in case
+# the user does not specify custom terms in the configuration file.
+DEFAULT_PAUTA_KEYWORDS = [
+    "consulta publica",
+    "tomada de subsidio",
+    "consulta externa",
+    "audiencia publica",
+    "leilao",
+    "isa energia",
+    "cteep",
+    "companhia de transmissao de energia eletrica paulista",
+    "interligacao eletrica",
+]
+
+DEFAULT_SORTEIO_KEYWORDS = [
+    "consulta publica",
+    "reajuste tarifario",
+    "rbse",
+    "tomada de subsidio",
+    "consulta externa",
+    "audiencia publica",
+    "leilao",
+    "isa energia",
+    "cteep",
+    "companhia de transmissao de energia eletrica paulista",
+    "interligacao eletrica",
+]
+
+
+def load_config(path: str | None = None) -> Dict[str, Any]:
+    """Return configuration dictionary from JSON file.
+
+    Parameters
+    ----------
+    path: str | None
+        Optional path to the configuration file.  When ``None`` it falls back
+        to ``DEFAULT_CONFIG_PATH``.
+    """
+
     config_path = path or DEFAULT_CONFIG_PATH
-    with open(config_path, 'r', encoding='utf-8') as f:
+    with open(config_path, "r", encoding="utf-8") as f:
         config = json.load(f)
 
-    smtp = config.setdefault('smtp', {})
-    smtp.setdefault('port', 587)
-    smtp.setdefault('starttls', False)
+    # Apply defaults
+    smtp = config.setdefault("smtp", {})
+    smtp.setdefault("port", 587)
+    smtp.setdefault("starttls", False)
+
+    keywords = config.setdefault("keywords", {})
+    keywords.setdefault("pauta", DEFAULT_PAUTA_KEYWORDS)
+    keywords.setdefault("sorteio", DEFAULT_SORTEIO_KEYWORDS)
+
+    config.setdefault("email", {}).setdefault("recipients", [])
+
     return config
+

--- a/pauta_aneel/keywords.example
+++ b/pauta_aneel/keywords.example
@@ -1,2 +1,0 @@
-consulta publica
-leilao

--- a/sorteio_aneel/keywords.example
+++ b/sorteio_aneel/keywords.example
@@ -1,2 +1,0 @@
-reajuste tarifario
-rbse

--- a/sorteio_aneel/sorteio_aneel.py
+++ b/sorteio_aneel/sorteio_aneel.py
@@ -15,10 +15,18 @@ import subprocess
 import json
 from pathlib import Path
 
-# Assegura que o diretório raiz do projeto esteja no PYTHONPATH
-ROOT_DIR = Path(__file__).resolve().parent
-if not (ROOT_DIR / "config_loader.py").exists():
-    ROOT_DIR = ROOT_DIR.parent
+# Garante que ``config_loader`` possa ser importado independentemente do local
+# de execução do script.
+CONFIG_ENV = os.environ.get("SEI_ANEEL_CONFIG")
+if CONFIG_ENV:
+    ROOT_DIR = Path(CONFIG_ENV).resolve().parent.parent
+else:
+    ROOT_DIR = Path(__file__).resolve()
+    for parent in ROOT_DIR.parents:
+        if (parent / "config_loader.py").exists():
+            ROOT_DIR = parent
+            break
+
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
@@ -28,7 +36,6 @@ from config_loader import load_config
 DATA_DIR = os.environ.get("SORTEIO_DATA_DIR", os.path.join(os.path.expanduser("~"), ".sorteio_aneel"))
 os.makedirs(DATA_DIR, exist_ok=True)
 LOG_FILE = os.environ.get("SORTEIO_LOG_FILE", os.path.join(DATA_DIR, "sorteio_aneel.log"))
-KEYWORDS_FILE = os.environ.get("KEYWORDS_FILE", os.path.join(DATA_DIR, ".sorteio_aneel_keywords"))
 
 # === Registro de data/hora de execução no log ===
 def registrar_log(mensagem):
@@ -58,24 +65,8 @@ LAST_RESULT_FILE = os.environ.get(
     "LAST_RESULT_FILE", os.path.join(DATA_DIR, "ultimo_resultado_aneel.json")
 )
 
-# Função para carregar termos de pesquisa do arquivo externo, se existir
-def load_keywords():
-    if os.path.isfile(KEYWORDS_FILE):
-        try:
-            with open(KEYWORDS_FILE, "r") as f:
-                keywords = [line.strip() for line in f if line.strip()]
-                if keywords:
-                    return keywords
-        except Exception as e:
-            registrar_log(f"Erro ao ler {KEYWORDS_FILE}: {e}")
-    # fallback para lista padrão
-    return [
-        "consulta publica", "reajuste tarifario", "rbse", "tomada de subsidio", "consulta externa", "audiencia publica",
-        "leilao", "isa energia", "cteep", "companhia de transmissao de energia eletrica paulista",
-        "interligacao eletrica"
-    ]
-
-KEYWORDS = load_keywords()
+# Termos de pesquisa definidos no arquivo de configuração global
+KEYWORDS = CONFIG.get("keywords", {}).get("sorteio", [])
 
 def normalize(s):
     if not isinstance(s, str):


### PR DESCRIPTION
## Summary
- Load SMTP, 2captcha, Google Drive and keyword settings from a single JSON file via `config_loader`
- Update `pauta_aneel.py` and `sorteio_aneel.py` to read keywords and config via shared loader
- Simplify `sei-aneel.sh` install scripts to use the global configuration and drop per-module configs

## Testing
- `python -m py_compile config_loader.py pauta_aneel/pauta_aneel.py sorteio_aneel/sorteio_aneel.py`
- `bash -n sei-aneel.sh`


------
https://chatgpt.com/codex/tasks/task_e_689687894248832b918ff4383a3f148b