### PR TITLE
Fix config_loader import path handling

### DIFF
--- a/backup_manager.py
+++ b/backup_manager.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 from datetime import datetime
 from pathlib import Path
 import zipfile

--- a/sei-aneel.py
+++ b/sei-aneel.py
@@ -19,7 +19,6 @@ import colorama
 from colorama import Fore, Back, Style
 import threading
 import signal
-from config_loader import DEFAULT_CONFIG_PATH
 
 # Garante que o diretório raiz esteja no PYTHONPATH para importar config_loader
 ROOT_DIR = Path(__file__).resolve().parent


### PR DESCRIPTION
## Summary
- ensure backup_manager imports `sys` before manipulating `sys.path`
- reorder imports in `sei-aneel.py` so project root is added to `sys.path` before importing `config_loader`

## Testing
- `python -m py_compile backup_manager.py sei-aneel.py`
- `python - <<'PY'
import json, os, tempfile
cfg_dir = tempfile.mkdtemp()
cfg_path = os.path.join(cfg_dir, 'configs.json')
json.dump({}, open(cfg_path, 'w'))
os.environ['SEI_ANEEL_CONFIG'] = cfg_path
for mod in ['backup_manager', 'sei-aneel', 'manage_processes', 'pauta_aneel.pauta_aneel', 'sorteio_aneel.sorteio_aneel', 'test_connectivity']:
    try:
        __import__(mod)
        print(mod, 'import ok')
    except Exception as e:
        print(mod, 'import fail:', e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68968b04a380832b88dcb171e6498bd3