### PR TITLE
Fix path handling in Pauta and Sorteio run scripts

### DIFF
--- a/sei-aneel.sh
+++ b/sei-aneel.sh
@@ -117,7 +117,7 @@ install_pauta() {
 
 cat <<RUN > "$PAUTA_DIR/run.sh"
 #!/bin/bash
-DIR="\$(dirname "$0")"
+DIR="\$(dirname "\$0")"
 cd "\$DIR"
 export SEI_ANEEL_CONFIG="$CONFIG_FILE"
 PAUTA_DATA_DIR="\$DIR"
@@ -219,7 +219,7 @@ install_sorteio() {
 cat <<RUN > "$SORTEIO_DIR/run.sh"
 #!/bin/bash
 
-DIR="\$(dirname "$0")"
+DIR="\$(dirname "\$0")"
 cd "\$DIR"
 export SEI_ANEEL_CONFIG="$CONFIG_FILE"
 SORTEIO_DATA_DIR="\$DIR"


### PR DESCRIPTION
## Summary
- ensure run scripts for Pauta and Sorteio resolve their directory at runtime
- prevent `python3: can't open file` errors when executing modules

## Testing
- `bash -n sei-aneel.sh`
- `python3 -m py_compile pauta_aneel/pauta_aneel.py sorteio_aneel/sorteio_aneel.py`
- `pytest` *(fails: fixture 'conf' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68975391f0b8832ba6e781a8bd1d0d71