### PR TITLE
Add external update script with config preservation

### DIFF
--- a/sei-aneel.sh
+++ b/sei-aneel.sh
@@ -12,6 +12,7 @@ CONFIG_DIR="$SCRIPT_DIR/config"
 CONFIG_FILE="$CONFIG_DIR/configs.json"
 LOG_DIR="$SCRIPT_DIR/logs"
 REPO_URL="https://github.com/aryabdo/sei-aneel.git"
+UPDATE_SCRIPT="$SCRIPT_DIR/update_repo.sh"
 
 export SEI_ANEEL_CONFIG="$CONFIG_FILE"
 
@@ -36,7 +37,7 @@ install_sei() {
   sudo rm -rf "$SCRIPT_DIR"
   sudo mkdir -p "$SCRIPT_DIR" "$LOG_DIR"
   sudo cp -r config "$SCRIPT_DIR/"
-  sudo cp sei-aneel.py manage_processes.py backup_manager.py test_connectivity.py requirements.txt "$SCRIPT_DIR/"
+  sudo cp sei-aneel.py manage_processes.py backup_manager.py test_connectivity.py requirements.txt update_repo.sh "$SCRIPT_DIR/"
   sudo cp "$CRED" "$CONFIG_DIR/credentials.json"
   sudo chown -R "$USER":"$USER" "$SCRIPT_DIR"
 
@@ -85,14 +86,11 @@ CFG
 }
 
 update_sei() {
-  TMP_DIR=$(mktemp -d)
-  git clone "$REPO_URL" "$TMP_DIR" >/dev/null 2>&1
-  sudo cp "$TMP_DIR/sei-aneel.py" "$TMP_DIR/manage_processes.py" "$TMP_DIR/backup_manager.py" "$TMP_DIR/test_connectivity.py" "$TMP_DIR/sei-aneel.sh" "$TMP_DIR/requirements.txt" "$SCRIPT_DIR/"
-  sudo cp -r "$TMP_DIR/config" "$SCRIPT_DIR/"
-  sudo chown -R "$USER":"$USER" "$SCRIPT_DIR"
-
-  rm -rf "$TMP_DIR"
-  echo -e "${GREEN}Atualização concluída.${NC}"
+  if [ -f "$UPDATE_SCRIPT" ]; then
+    sudo bash "$UPDATE_SCRIPT"
+  else
+    echo -e "${RED}Script de atualização não encontrado em $UPDATE_SCRIPT.${NC}"
+  fi
 }
 
 remove_sei() {

--- a/update_repo.sh
+++ b/update_repo.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Atualiza o projeto SEI ANEEL preservando o arquivo de configuração
+
+REPO_URL="https://github.com/aryabdo/sei-aneel.git"
+TARGET_DIR="/opt/sei-aneel"
+CONFIG_DIR="$TARGET_DIR/config"
+
+# cria diretório temporário para backup
+TEMP_DIR=$(mktemp -d)
+
+if [ -d "$CONFIG_DIR" ]; then
+  cp -r "$CONFIG_DIR" "$TEMP_DIR/" 2>/dev/null
+fi
+
+# garante que não estamos dentro do diretório a ser removido
+cd /
+
+# remove instalação antiga
+sudo rm -rf "$TARGET_DIR"
+
+# clona nova versão
+sudo git clone "$REPO_URL" "$TARGET_DIR"
+
+# restaura configurações
+if [ -d "$TEMP_DIR/config" ]; then
+  sudo rm -rf "$CONFIG_DIR"
+  sudo mv "$TEMP_DIR/config" "$CONFIG_DIR"
+fi
+
+rm -rf "$TEMP_DIR"
+
+# ajusta permissões
+sudo chown -R "$USER":"$USER" "$TARGET_DIR"
+
+echo "Atualização concluída."


### PR DESCRIPTION
## Summary
- add `update_repo.sh` to refresh installation, preserving existing configuration
- reference external updater in `sei-aneel.sh` and include it in installation

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6897597b0d5c832b80809dd627db8a67