### PR TITLE
Centralize search term management

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -13,7 +13,7 @@ import json
 import os
 import shutil
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 # Directory where configuration files are stored.  ``SEI_ANEEL_CONFIG`` can be
 # used to override the location of ``configs.json``; otherwise the project uses
@@ -66,6 +66,33 @@ _DEFAULT_SORTEIO_KEYWORDS = [
     "interligacao eletrica",
 ]
 
+# Caminho do arquivo que concentra os termos de pesquisa
+DEFAULT_TERMS_PATH = CONFIG_DIR / "search_terms.txt"
+
+# Lista de termos padrão utilizada para preencher o arquivo quando inexistente
+_DEFAULT_SEARCH_TERMS = sorted(
+    set(_DEFAULT_PAUTA_KEYWORDS + _DEFAULT_SORTEIO_KEYWORDS)
+)
+
+
+def ensure_terms_file(path: Path = DEFAULT_TERMS_PATH) -> None:
+    """Garante a existência do arquivo de termos de pesquisa."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        with open(path, "w", encoding="utf-8") as f:
+            for term in _DEFAULT_SEARCH_TERMS:
+                f.write(f"{term}\n")
+
+
+def load_search_terms(path: str | Path | None = None) -> List[str]:
+    """Carrega os termos de pesquisa a partir de ``search_terms.txt``."""
+
+    terms_path = Path(path) if path else DEFAULT_TERMS_PATH
+    ensure_terms_file(terms_path)
+    with open(terms_path, "r", encoding="utf-8") as f:
+        return [line.strip() for line in f if line.strip()]
+
 
 def load_config(path: str | Path | None = None) -> Dict[str, Any]:
     """Return configuration dictionary from JSON file.
@@ -89,13 +116,14 @@ def load_config(path: str | Path | None = None) -> Dict[str, Any]:
     smtp.setdefault("port", 587)
     smtp.setdefault("starttls", False)
 
-    keywords = config.setdefault("keywords", {})
-    keywords.setdefault("pauta", _DEFAULT_PAUTA_KEYWORDS)
-    keywords.setdefault("sorteio", _DEFAULT_SORTEIO_KEYWORDS)
-
     config.setdefault("email", {}).setdefault("recipients", [])
 
     return config
 
 
-__all__ = ["load_config", "DEFAULT_CONFIG_PATH", "ensure_config_file"]
+__all__ = [
+    "load_config",
+    "DEFAULT_CONFIG_PATH",
+    "ensure_config_file",
+    "load_search_terms",
+]

--- a/config/configs.example.json
+++ b/config/configs.example.json
@@ -17,32 +17,6 @@
   "email": {
     "recipients": ["destinatario@exemplo.com"]
   },
-  "keywords": {
-    "pauta": [
-      "consulta publica",
-      "tomada de subsidio",
-      "consulta externa",
-      "audiencia publica",
-      "leilao",
-      "isa energia",
-      "cteep",
-      "companhia de transmissao de energia eletrica paulista",
-      "interligacao eletrica"
-    ],
-    "sorteio": [
-      "consulta publica",
-      "reajuste tarifario",
-      "rbse",
-      "tomada de subsidio",
-      "consulta externa",
-      "audiencia publica",
-      "leilao",
-      "isa energia",
-      "cteep",
-      "companhia de transmissao de energia eletrica paulista",
-      "interligacao eletrica"
-    ]
-  },
   "paths": {
     "tesseract": "/usr/bin/tesseract",
     "chromedriver": "/usr/bin/chromedriver",

--- a/config/search_terms.txt
+++ b/config/search_terms.txt
@@ -1,0 +1,11 @@
+consulta publica
+tomada de subsidio
+consulta externa
+audiencia publica
+leilao
+isa energia
+cteep
+companhia de transmissao de energia eletrica paulista
+interligacao eletrica
+reajuste tarifario
+rbse

--- a/pauta_aneel/pauta_aneel.py
+++ b/pauta_aneel/pauta_aneel.py
@@ -22,7 +22,7 @@ from pathlib import Path
 ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
-from config import load_config
+from config import load_config, load_search_terms
 
 # Diretório de dados e arquivos de log
 DATA_DIR = os.environ.get("PAUTA_DATA_DIR", os.path.join(os.path.expanduser("~"), ".pauta_aneel"))
@@ -54,8 +54,8 @@ EMAIL_TO = ",".join(CONFIG.get("email", {}).get("recipients", []))
 BASE_URL = "https://www2.aneel.gov.br/aplicacoes_liferay/noticias_area/?idAreaNoticia=425"
 SITE_PREFIX = "https://www2.aneel.gov.br"
 
-# Termos de pesquisa obtidos do arquivo de configuração global
-KEYWORDS = CONFIG.get("keywords", {}).get("pauta", [])
+# Termos de pesquisa centralizados em ``search_terms.txt``
+KEYWORDS = load_search_terms()
 
 def normalize(s):
     if not isinstance(s, str):

--- a/sorteio_aneel/sorteio_aneel.py
+++ b/sorteio_aneel/sorteio_aneel.py
@@ -21,7 +21,7 @@ from pathlib import Path
 ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
-from config import load_config
+from config import load_config, load_search_terms
 
 # Diretório de dados e arquivos de log
 DATA_DIR = os.environ.get("SORTEIO_DATA_DIR", os.path.join(os.path.expanduser("~"), ".sorteio_aneel"))
@@ -56,8 +56,8 @@ LAST_RESULT_FILE = os.environ.get(
     "LAST_RESULT_FILE", os.path.join(DATA_DIR, "ultimo_resultado_aneel.json")
 )
 
-# Termos de pesquisa definidos no arquivo de configuração global
-KEYWORDS = CONFIG.get("keywords", {}).get("sorteio", [])
+# Termos de pesquisa centralizados em ``search_terms.txt``
+KEYWORDS = load_search_terms()
 
 def normalize(s):
     if not isinstance(s, str):


### PR DESCRIPTION
## Summary
- Move ANEEL search terms to new `search_terms.txt` with helper loader
- Add Configurações > Termos de Pesquisa menu to manage shared search terms
- Simplify module menus to drop install/update/remove/cron options

## Testing
- `python -m py_compile config/__init__.py pauta_aneel/pauta_aneel.py sorteio_aneel/sorteio_aneel.py`
- `bash -n sei-aneel.sh`


------
https://chatgpt.com/codex/tasks/task_e_68976785ecec832bbf22c5d6f1d85aa2