### PR TITLE
feat: expand cron scheduling options

### DIFF
--- a/sei-aneel.sh
+++ b/sei-aneel.sh
@@ -162,10 +162,12 @@ force_run_pauta() {
 }
 
 schedule_cron_pauta() {
+  read -p "Minutos [0]: " MIN; MIN=${MIN:-0}
+  read -p "Horas [*]: " H; H=${H:-*}
   read -p "Dias do mês [*]: " M; M=${M:-*}
+  read -p "Meses [*]: " MO; MO=${MO:-*}
   read -p "Dias da semana [*]: " D; D=${D:-*}
-  read -p "Horas (ex: 7,19): " H
-  (crontab -l 2>/dev/null | grep -v 'pauta_aneel.py'; echo "0 $H $M * $D $PAUTA_DIR/run.sh >> $PAUTA_LOG_DIR/cron.log 2>&1") | crontab -
+  (crontab -l 2>/dev/null | grep -v 'pauta_aneel.py'; echo "$MIN $H $M $MO $D $PAUTA_DIR/run.sh >> $PAUTA_LOG_DIR/cron.log 2>&1") | crontab -
   echo -e "${GREEN}Cron agendado.${NC}"
 }
 
@@ -351,10 +353,12 @@ force_run_sorteio() {
 }
 
 schedule_cron_sorteio() {
+  read -p "Minutos [0]: " MIN; MIN=${MIN:-0}
+  read -p "Horas [*]: " H; H=${H:-*}
   read -p "Dias do mês [*]: " M; M=${M:-*}
+  read -p "Meses [*]: " MO; MO=${MO:-*}
   read -p "Dias da semana [*]: " D; D=${D:-*}
-  read -p "Horas (ex: 6,18): " H
-  (crontab -l 2>/dev/null | grep -v 'sorteio_aneel.py'; echo "0 $H $M * $D $SORTEIO_DIR/run.sh >> $SORTEIO_LOG_DIR/cron.log 2>&1") | crontab -
+  (crontab -l 2>/dev/null | grep -v 'sorteio_aneel.py'; echo "$MIN $H $M $MO $D $SORTEIO_DIR/run.sh >> $SORTEIO_LOG_DIR/cron.log 2>&1") | crontab -
   echo -e "${GREEN}Cron agendado.${NC}"
 }
 
@@ -566,10 +570,12 @@ force_run() {
 }
 
 schedule_cron() {
+  read -p "Minutos [0]: " MIN; MIN=${MIN:-0}
+  read -p "Horas [*]: " H; H=${H:-*}
   read -p "Dias do mês [*]: " M; M=${M:-*}
+  read -p "Meses [*]: " MO; MO=${MO:-*}
   read -p "Dias da semana [*]: " D; D=${D:-*}
-  read -p "Horas (ex: 5,13,16): " H
-  (crontab -l 2>/dev/null | grep -v 'sei-aneel.py'; echo "0 $H $M * $D /usr/bin/python3 $SCRIPT_DIR/sei-aneel.py >> $LOG_DIR/cron.log 2>&1") | crontab -
+  (crontab -l 2>/dev/null | grep -v 'sei-aneel.py'; echo "$MIN $H $M $MO $D /usr/bin/python3 $SCRIPT_DIR/sei-aneel.py >> $LOG_DIR/cron.log 2>&1") | crontab -
   echo -e "${GREEN}Cron agendado.${NC}"
 }
 


### PR DESCRIPTION
## Summary
- allow minute, hour, day, month and weekday selection for SEI cron
- expand Pauta cron prompts to include minute and month settings
- expand Sorteio cron prompts with minute and month options

## Testing
- `bash -n sei-aneel.sh`


------
https://chatgpt.com/codex/tasks/task_e_6897e8f8f1c8832ba49fb680b2f05cc0