### PR TITLE
Fix missing email_utils import errors in scripts

### DIFF
--- a/pauta_aneel/pauta_aneel.py
+++ b/pauta_aneel/pauta_aneel.py
@@ -26,7 +26,13 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
 from config import load_config, load_search_terms
-from email_utils import format_html_email
+# ``email_utils`` pode não estar disponível quando o script é chamado
+# diretamente fora do repositório. Tentamos o import absoluto e, se
+# necessário, o relativo para suportar execução como pacote.
+try:  # pragma: no cover - lógica de fallback
+    from email_utils import format_html_email
+except ModuleNotFoundError:  # pragma: no cover - suporte a pacote
+    from ..email_utils import format_html_email  # type: ignore
 from log_utils import get_logger
 
 # Diretório de dados e arquivos de log

--- a/sei-aneel.py
+++ b/sei-aneel.py
@@ -26,7 +26,14 @@ ROOT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(ROOT_DIR))
 
 from config import DEFAULT_CONFIG_PATH, load_config
-from email_utils import format_html_email, attach_bytes, hash_content
+# ``email_utils`` pode não estar no PYTHONPATH quando o script é
+# executado fora do repositório. Tentamos primeiro o import absoluto
+# e, em caso de falha, caímos para o import relativo quando o projeto
+# estiver instalado como pacote.
+try:  # pragma: no cover - lógica de fallback
+    from email_utils import format_html_email, attach_bytes, hash_content
+except ModuleNotFoundError:  # pragma: no cover - suporte a execução como pacote
+    from .email_utils import format_html_email, attach_bytes, hash_content  # type: ignore
 from ui import InteractiveUI
 from progress import ProgressTracker
 

--- a/sorteio_aneel/sorteio_aneel.py
+++ b/sorteio_aneel/sorteio_aneel.py
@@ -25,7 +25,13 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
 from config import load_config, load_search_terms
-from email_utils import format_html_email
+# ``email_utils`` pode não estar disponível quando executado fora do
+# repositório. O import relativo permite que o módulo seja usado mesmo
+# quando o projeto estiver instalado como pacote.
+try:  # pragma: no cover - lógica de fallback
+    from email_utils import format_html_email
+except ModuleNotFoundError:  # pragma: no cover - suporte a pacote
+    from ..email_utils import format_html_email  # type: ignore
 from log_utils import get_logger
 
 # Diretório de dados e arquivos de log


### PR DESCRIPTION
## Summary
- Add fallback relative imports for email utilities to prevent `ModuleNotFoundError` when running scripts from different locations
- Apply same fallback logic to pauta and sorteio scripts

## Testing
- `python sei-aneel.py`
- `python pauta_aneel/pauta_aneel.py` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python sorteio_aneel/sorteio_aneel.py` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python manage_processes.py` *(fails: missing arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68991d7f6368832b9a45104780944d21