### PR TITLE
Fix missing imports and package installation paths

### DIFF
--- a/manage_processes.py
+++ b/manage_processes.py
@@ -2,9 +2,8 @@
 """Gerencia a planilha de processos no Google Sheets."""
 
 import argparse
-import json
 import re
-from pathlib import Path
+import sys
 
 import gspread
 from oauth2client.service_account import ServiceAccountCredentials

--- a/sei-aneel.sh
+++ b/sei-aneel.sh
@@ -68,7 +68,7 @@ install_sei() {
 
   sudo rm -rf "$SCRIPT_DIR"
   sudo mkdir -p "$SCRIPT_DIR" "$LOG_DIR"
-  sudo cp -r sei_aneel/config "$SCRIPT_DIR/"
+  sudo cp -r sei_aneel "$SCRIPT_DIR/"
   sudo cp sei-aneel.py manage_processes.py backup_manager.py test_connectivity.py requirements.txt update_repo.sh "$SCRIPT_DIR/"
   sudo cp "$CRED" "$CONFIG_DIR/credentials.json"
   sudo chown -R "$ACTIVE_USER":"$ACTIVE_USER" "$SCRIPT_DIR"
@@ -135,7 +135,7 @@ install_pauta() {
   sudo chown -R "$ACTIVE_USER":"$ACTIVE_USER" "$PAUTA_DIR"
 
   sudo mkdir -p "$SCRIPT_DIR"
-  sudo cp -r sei_aneel/config "$SCRIPT_DIR/" 2>/dev/null
+  sudo cp -r sei_aneel "$SCRIPT_DIR/" 2>/dev/null
 
   sudo apt-get update
   sudo apt-get install -y python3 python3-pip
@@ -254,7 +254,7 @@ install_sorteio() {
   sudo chown -R "$ACTIVE_USER":"$ACTIVE_USER" "$SORTEIO_DIR"
 
   sudo mkdir -p "$SCRIPT_DIR"
-  sudo cp -r sei_aneel/config "$SCRIPT_DIR/" 2>/dev/null
+  sudo cp -r sei_aneel "$SCRIPT_DIR/" 2>/dev/null
 
   sudo apt-get update
   sudo apt-get install -y python3 python3-pip

--- a/sei_aneel/pauta_aneel/pauta_aneel.py
+++ b/sei_aneel/pauta_aneel/pauta_aneel.py
@@ -15,10 +15,10 @@ import tempfile
 import subprocess
 from urllib.parse import urljoin
 import hashlib
-from pathlib import Path
 import html
 import logging
 import shutil
+import sys
 
 from ..config import load_config, load_search_terms
 from ..email_utils import format_html_email

--- a/sei_aneel/sorteio_aneel/sorteio_aneel.py
+++ b/sei_aneel/sorteio_aneel/sorteio_aneel.py
@@ -14,10 +14,10 @@ import unicodedata
 import tempfile
 import subprocess
 import json
-from pathlib import Path
 import html
 import logging
 import shutil
+import sys
 
 from ..config import load_config, load_search_terms
 from ..email_utils import format_html_email


### PR DESCRIPTION
## Summary
- add missing `sys` imports to script modules
- copy entire `sei_aneel` package during installation steps

## Testing
- `python -m py_compile manage_processes.py sei_aneel/pauta_aneel/pauta_aneel.py sei_aneel/sorteio_aneel/sorteio_aneel.py sei-aneel.py`
- `python manage_processes.py --help`
- `python sei-aneel.py --help`
- `python backup_manager.py --help`


------
https://chatgpt.com/codex/tasks/task_e_689926520c78832b9502cdc94a7fff7f