### PR TITLE
Ensure config directory exists during installation

### DIFF
--- a/sei-aneel.sh
+++ b/sei-aneel.sh
@@ -67,7 +67,7 @@ install_sei() {
   read -p "Emails destinatários (separados por vírgula): " EMAILS
 
   sudo rm -rf "$SCRIPT_DIR"
-  sudo mkdir -p "$SCRIPT_DIR" "$LOG_DIR"
+  sudo mkdir -p "$SCRIPT_DIR" "$LOG_DIR" "$CONFIG_DIR"
   sudo cp -r sei_aneel "$SCRIPT_DIR/"
   sudo cp sei-aneel.py manage_processes.py backup_manager.py test_connectivity.py requirements.txt update_repo.sh "$SCRIPT_DIR/"
   sudo cp "$CRED" "$CONFIG_DIR/credentials.json"


### PR DESCRIPTION
## Summary
- create configuration directory before copying credentials in install script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68995b459640832b8877ecb76edc5ced