### PR TITLE
Fix config imports in standalone scripts

### DIFF
--- a/sei_aneel/pauta_aneel/pauta_aneel.py
+++ b/sei_aneel/pauta_aneel/pauta_aneel.py
@@ -27,10 +27,11 @@ try:
 except ImportError:  # pragma: no cover - allow direct execution
     from pathlib import Path
 
-    sys.path.append(str(Path(__file__).resolve().parents[1]))
-    from config import load_config, load_search_terms
-    from email_utils import format_html_email
-    from log_utils import get_logger
+    # Allow running the script directly by adding the project root to ``sys.path``
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
+    from sei_aneel.config import load_config, load_search_terms
+    from sei_aneel.email_utils import format_html_email
+    from sei_aneel.log_utils import get_logger
 
 # Diretório de dados e arquivos de log
 DATA_DIR = os.environ.get("PAUTA_DATA_DIR", os.path.join(os.path.expanduser("~"), ".pauta_aneel"))

--- a/sei_aneel/sorteio_aneel/sorteio_aneel.py
+++ b/sei_aneel/sorteio_aneel/sorteio_aneel.py
@@ -26,10 +26,11 @@ try:
 except ImportError:  # pragma: no cover - allow direct execution
     from pathlib import Path
 
-    sys.path.append(str(Path(__file__).resolve().parents[1]))
-    from config import load_config, load_search_terms
-    from email_utils import format_html_email
-    from log_utils import get_logger
+    # Allow running the script directly by adding the project root to ``sys.path``
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
+    from sei_aneel.config import load_config, load_search_terms
+    from sei_aneel.email_utils import format_html_email
+    from sei_aneel.log_utils import get_logger
 
 # Diretório de dados e arquivos de log
 DATA_DIR = os.environ.get("SORTEIO_DATA_DIR", os.path.join(os.path.expanduser("~"), ".sorteio_aneel"))


### PR DESCRIPTION
## Summary
- ensure standalone execution of `sorteio_aneel` and `pauta_aneel` by appending the project root to `sys.path`
- use absolute `sei_aneel` package imports for configuration, email, and logging utilities

## Testing
- `python -m py_compile sei_aneel/sorteio_aneel/sorteio_aneel.py sei_aneel/pauta_aneel/pauta_aneel.py`


------
https://chatgpt.com/codex/tasks/task_e_6899ed067534832ba3da13604165d4f2