### PR TITLE
feat: add backup restore option

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,12 +226,12 @@ O sistema possui backup automático de:
 - 📝 Logs
 - 📊 Histórico de execução
 
-Gerenciar backups:
+Gerenciar backups e restaurações:
 ```bash
 sei-aneel backup
 ```
 
-Os arquivos são guardados localmente em `backups/` e, quando configurado `google_drive.backup_folder_id`, também são enviados para o Google Drive (por exemplo, `Meu Drive/Servidor/Backup/Sistema PAINEEL`). Apenas os três backups mais recentes são mantidos, removendo os mais antigos automaticamente.
+Pelo menu acima é possível criar ou restaurar backups. Os arquivos são guardados localmente em `backups/` e, quando configurado `google_drive.backup_folder_id`, também podem ser enviados para o Google Drive (por exemplo, `Meu Drive/Servidor/Backup/Sistema PAINEEL`). Apenas os três backups mais recentes são mantidos, removendo os mais antigos automaticamente.
 
 ## 📝 Logs
 

--- a/backup_manager.py
+++ b/backup_manager.py
@@ -6,6 +6,7 @@ import zipfile
 from datetime import datetime
 from pathlib import Path
 import logging
+import tempfile
 
 from sei_aneel.config import DEFAULT_CONFIG_PATH, load_config
 from sei_aneel.log_utils import get_logger
@@ -89,21 +90,133 @@ def backup_gdrive(config_path: str = DEFAULT_CONFIG_PATH) -> None:
     creds_file = config.get('google_drive', {}).get('credentials_file')
     folder_id = config.get('google_drive', {}).get('backup_folder_id')
     if not creds_file or not folder_id:
-        logger.error('Credenciais do Google Drive ou ID da pasta não definidos.')
+        logger.error(
+            'Credenciais do Google Drive ou ID da pasta de backup não definidos no arquivo de configuração.'
+        )
         return
     backup_file = backup_local(config_path)
     upload_to_drive(backup_file, creds_file, folder_id)
 
+
+def _restore_zip(zip_path: Path, base_dir: Path) -> None:
+    """Extract ``zip_path`` into ``base_dir`` replacing existing files."""
+
+    with zipfile.ZipFile(zip_path, 'r') as zf:
+        zf.extractall(base_dir)
+    logger.info(f'Backup restaurado a partir de {zip_path}')
+
+
+def restore_local(config_path: str = DEFAULT_CONFIG_PATH) -> None:
+    cfg_path = Path(config_path)
+    base_dir = cfg_path.parent.parent
+    backup_dir = base_dir / 'backups'
+    backups = sorted(backup_dir.glob('sei_aneel_backup_*.zip'), reverse=True)
+    if not backups:
+        logger.error('Nenhum backup local encontrado.')
+        return
+
+    for idx, bkp in enumerate(backups, start=1):
+        print(f"{idx}) {bkp.name}")
+
+    choice = input('Selecione o backup: ')
+    if not choice.isdigit() or int(choice) < 1 or int(choice) > len(backups):
+        logger.error('Opção inválida.')
+        return
+
+    _restore_zip(backups[int(choice) - 1], base_dir)
+
+
+def restore_gdrive(config_path: str = DEFAULT_CONFIG_PATH) -> None:
+    config = load_config(config_path)
+    creds_file = config.get('google_drive', {}).get('credentials_file')
+    folder_id = config.get('google_drive', {}).get('backup_folder_id')
+    if not creds_file or not folder_id:
+        logger.error(
+            'Credenciais do Google Drive ou ID da pasta de backup não definidos no arquivo de configuração.'
+        )
+        return
+
+    try:
+        from google.oauth2.service_account import Credentials
+        from googleapiclient.discovery import build
+        from googleapiclient.http import MediaIoBaseDownload
+    except Exception as e:
+        logger.error(f'Bibliotecas do Google não disponíveis: {e}')
+        return
+
+    scopes = ['https://www.googleapis.com/auth/drive']
+    creds = Credentials.from_service_account_file(creds_file, scopes=scopes)
+    service = build('drive', 'v3', credentials=creds)
+
+    query = f"'{folder_id}' in parents and name contains 'sei_aneel_backup_'"
+    results = service.files().list(
+        q=query,
+        spaces='drive',
+        fields='files(id, name, createdTime)',
+        supportsAllDrives=True,
+        includeItemsFromAllDrives=True,
+    ).execute()
+    files = sorted(results.get('files', []), key=lambda x: x['createdTime'], reverse=True)
+    if not files:
+        logger.error('Nenhum backup encontrado no Google Drive.')
+        return
+
+    for idx, f in enumerate(files, start=1):
+        created = f.get('createdTime', '')[:19].replace('T', ' ')
+        print(f"{idx}) {f['name']} ({created})")
+
+    choice = input('Selecione o backup: ')
+    if not choice.isdigit() or int(choice) < 1 or int(choice) > len(files):
+        logger.error('Opção inválida.')
+        return
+
+    selected = files[int(choice) - 1]
+    request = service.files().get_media(fileId=selected['id'])
+    fd, tmp_path = tempfile.mkstemp(suffix='.zip')
+    try:
+        with os.fdopen(fd, 'wb') as fh:
+            downloader = MediaIoBaseDownload(fh, request)
+            done = False
+            while not done:
+                _, done = downloader.next_chunk()
+
+        cfg_path = Path(config_path)
+        base_dir = cfg_path.parent.parent
+        _restore_zip(Path(tmp_path), base_dir)
+    finally:
+        try:
+            os.remove(tmp_path)
+        except OSError:
+            pass
+
+
+def restore_menu(config_path: str = DEFAULT_CONFIG_PATH) -> None:
+    print('1) Backup local')
+    print('2) Backup Google Drive')
+    op = input('Opção: ')
+    if op == '1':
+        restore_local(config_path)
+    elif op == '2':
+        restore_gdrive(config_path)
+    else:
+        logger.error('Opção inválida.')
+
 def main():
     parser = argparse.ArgumentParser(description='Gerenciador de backups PAINEEL')
-    parser.add_argument('mode', choices=['local', 'gdrive'], help='Tipo de backup a executar')
+    parser.add_argument(
+        'mode',
+        choices=['local', 'gdrive', 'restore'],
+        help='Ação a executar: gerar backup local, no Google Drive ou restaurar',
+    )
     parser.add_argument('--config', default=DEFAULT_CONFIG_PATH, help='Caminho para configs.json')
     args = parser.parse_args()
 
     if args.mode == 'local':
         backup_local(args.config)
-    else:
+    elif args.mode == 'gdrive':
         backup_gdrive(args.config)
+    else:
+        restore_menu(args.config)
 
 if __name__ == '__main__':
     main()

--- a/sei-aneel.sh
+++ b/sei-aneel.sh
@@ -750,12 +750,14 @@ backup_menu() {
     show_header "Backup"
     echo -e "${CYAN}1) Backup local${NC}"
     echo -e "${CYAN}2) Backup Google Drive${NC}"
-    echo -e "${CYAN}3) Voltar${NC}"
+    echo -e "${CYAN}3) Restaurar backup${NC}"
+    echo -e "${CYAN}4) Voltar${NC}"
     read -p $'\e[33mOpção: \e[0m' op
     case $op in
       1) python3 "$SCRIPT_DIR/backup_manager.py" local; pause ;;
       2) python3 "$SCRIPT_DIR/backup_manager.py" gdrive; pause ;;
-      3) break ;;
+      3) python3 "$SCRIPT_DIR/backup_manager.py" restore; pause ;;
+      4) break ;;
       *) echo -e "${RED}Opção inválida${NC}"; pause ;;
     esac
   done


### PR DESCRIPTION
## Summary
- add restoration of backups from local or Google Drive
- extend backup menu with restore option
- document backup/restore in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a08d961cc832bbbc4ac42a7ddadfe