### PR TITLE
Protect header row in Google Sheets operations

### DIFF
--- a/manage_processes.py
+++ b/manage_processes.py
@@ -38,7 +38,7 @@ def add_process(sheet, numero):
 def remove_process(sheet, numero):
     col = sheet.col_values(1)
     numero_norm = normalize(numero)
-    for idx, val in enumerate(col, start=1):
+    for idx, val in enumerate(col[1:], start=2):
         if normalize(val) == numero_norm:
             sheet.delete_rows(idx)
             print(f'Processo {numero} removido.')
@@ -49,7 +49,7 @@ def remove_process(sheet, numero):
 def update_process(sheet, old, new):
     col = sheet.col_values(1)
     old_norm = normalize(old)
-    for idx, val in enumerate(col, start=1):
+    for idx, val in enumerate(col[1:], start=2):
         if normalize(val) == old_norm:
             sheet.update_acell(f'A{idx}', new)
             print(f'Processo {old} atualizado para {new}.')

--- a/sei-aneel.py
+++ b/sei-aneel.py
@@ -787,9 +787,9 @@ class PlanilhaHandler:
         def _find_row():
             proc_col = self.sheet.col_values(1)
             proc_number_norm = self.normalizar_numero(proc_number)
-            for idx, val in enumerate(proc_col):
+            for idx, val in enumerate(proc_col[1:], start=2):
                 if self.normalizar_numero(val) == proc_number_norm:
-                    return idx + 1
+                    return idx
             return None
         
         return operacao_com_retry(_find_row, logger=self.logger)


### PR DESCRIPTION
## Summary
- Avoid modifying the header row in Google Sheets when removing or updating processes
- Skip the first row when looking up processes before updating existing rows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689a133a613c832ba54285a6f93bf363