### PR TITLE
Corrige fórmula de hyperlink em Documento na planilha

### DIFF
--- a/sei-aneel.py
+++ b/sei-aneel.py
@@ -1169,7 +1169,8 @@ def processar_processo(proc: str, driver, planilha_handler: Optional[PlanilhaHan
                 texto_safe = texto.replace('"', '\\"')
                 if link:
                     link_safe = link.replace('"', '\\"')
-                    doc_formula_parts.append(f'HYPERLINK("{link_safe}", "{texto_safe}")')
+                    # Usa ';' para compatibilidade com locale PT-BR nas fórmulas
+                    doc_formula_parts.append(f'HYPERLINK("{link_safe}"; "{texto_safe}")')
                 else:
                     doc_formula_parts.append(f'"{texto_safe}"')
             doc_nr = "=" + "&CHAR(10)&".join(doc_formula_parts) if doc_formula_parts else ""


### PR DESCRIPTION
## Summary
- Ajusta fórmula `HYPERLINK` usando `;` como separador para compatibilidade com planilhas em PT-BR
- Garante que Documento (coluna D) e email exibam texto âncora com link correto

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a255d5c54832bb0b9927e5248f5dd