### PR TITLE
Automate scheduling for ANEEL monitoring scripts

### DIFF
--- a/pauta-aneel.py
+++ b/pauta-aneel.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+"""Entry point for monitoring ANEEL meeting agendas."""
+from sei_aneel.scheduler import ensure_cron
+from sei_aneel.pauta_aneel.pauta_aneel import main
+
+
+if __name__ == "__main__":
+    ensure_cron([10, 11, 12, 13, 14], __file__, "pauta-aneel")
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ colorama
 requests
 beautifulsoup4
 google-api-python-client
+python-crontab

--- a/sei-aneel.py
+++ b/sei-aneel.py
@@ -24,6 +24,7 @@ from sei_aneel.config import DEFAULT_CONFIG_PATH, load_config
 from sei_aneel.email_utils import format_html_email, attach_bytes, hash_content
 from sei_aneel.ui import InteractiveUI
 from sei_aneel.progress import ProgressTracker
+from sei_aneel.scheduler import ensure_cron
 
 # Inicializa colorama para Windows
 colorama.init(autoreset=True)
@@ -1850,6 +1851,7 @@ def enviar_tabela_completa_email(planilha_handler: PlanilhaHandler,
         logger.error(f"Erro ao enviar tabela completa: {e}")
 
 if __name__ == "__main__":
+    ensure_cron([5, 12, 17], __file__, "sei-aneel")
     try:
         resultados = main()
         sucesso = len([r for r in resultados if r["status"] in ["atualizado", "inserido", "processado"]])

--- a/sei_aneel/scheduler.py
+++ b/sei_aneel/scheduler.py
@@ -1,0 +1,36 @@
+"""Utilities for installing cron jobs for automation scripts."""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+try:
+    from crontab import CronTab
+except Exception:  # pragma: no cover - cron may be unavailable
+    CronTab = None
+
+
+def ensure_cron(hours: list[int], script_path: str, comment: str) -> None:
+    """Ensure cron jobs exist for running *script_path* at given *hours* daily.
+
+    Parameters
+    ----------
+    hours: list[int]
+        List of hours (0-23) when the script should run, using minute 0.
+    script_path: str
+        Path to the script to schedule.
+    comment: str
+        Comment used to identify cron jobs so duplicates are avoided.
+    """
+    if CronTab is None:
+        return
+    try:
+        cron = CronTab(user=True)
+    except Exception:
+        return
+
+    cron.remove_all(comment=comment)
+    command = f"{sys.executable} {Path(script_path).resolve()}"
+    for hour in hours:
+        job = cron.new(command=command, comment=comment)
+        job.setall(f"0 {int(hour)} * * *")
+    cron.write()

--- a/sorteio-aneel.py
+++ b/sorteio-aneel.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+"""Entry point for monitoring ANEEL public draws."""
+from sei_aneel.scheduler import ensure_cron
+from sei_aneel.sorteio_aneel.sorteio_aneel import main
+
+
+if __name__ == "__main__":
+    ensure_cron([10, 11, 12, 13, 14], __file__, "sorteio-aneel")
+    main()


### PR DESCRIPTION
## Summary
- add cron job utility and integrate with existing monitoring scripts
- expose new entry points for pauta and sorteio monitoring
- schedule sei-aneel, pauta-aneel and sorteio-aneel scripts at required times

## Testing
- `pip install python-crontab` *(fails: Could not connect to proxy, No matching distribution found for python-crontab)*
- `pytest -q`
- `python -m py_compile pauta-aneel.py sorteio-aneel.py sei-aneel.py`


------
https://chatgpt.com/codex/tasks/task_e_689a47747048832b97b84579bbaa25d5