### PR TITLE
Send emails only on changes and attach XLSX results

### DIFF
--- a/sei-aneel.py
+++ b/sei-aneel.py
@@ -1836,6 +1836,18 @@ def enviar_tabela_completa_email(planilha_handler: PlanilhaHandler,
         parte_html = MIMEText(corpo_html, 'html', 'utf-8')
         msg.attach(parte_html)
 
+        try:
+            xlsx_data = planilha_handler.sheet.spreadsheet.export('xlsx')
+            attach_bytes(
+                msg,
+                xlsx_data,
+                'processos.xlsx',
+                'application',
+                'vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+            )
+        except Exception as e:
+            logger.warning(f"Falha ao exportar planilha: {e}")
+
         server = smtplib.SMTP(smtp_config['server'], smtp_config.get('port', 587))
         server.ehlo()
         if smtp_config.get('starttls', False):

--- a/sei_aneel/email_utils.py
+++ b/sei_aneel/email_utils.py
@@ -54,3 +54,82 @@ def hash_content(lines: Iterable[str]) -> str:
     for line in lines:
         h.update(line.encode('utf-8'))
     return h.hexdigest()
+
+
+def create_xlsx(headers: list[str], rows: list[list[str]]) -> bytes:
+    """Create a minimal XLSX file and return its bytes.
+
+    This function builds the necessary XML files for a simple worksheet and
+    packages them in a ZIP container following the XLSX specification. It
+    avoids external dependencies like *openpyxl*.
+
+    Parameters
+    ----------
+    headers: list[str]
+        Column titles to use in the first row.
+    rows: list[list[str]]
+        Subsequent rows of data where each inner list represents a row.
+    """
+    from io import BytesIO
+    from zipfile import ZipFile, ZIP_DEFLATED
+
+    def esc(value: str) -> str:
+        return (value or '').replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+
+    def col_letter(idx: int) -> str:
+        return chr(ord('A') + idx)
+
+    sheet_rows = []
+    header_cells = ''.join(
+        f'<c t="inlineStr" r="{col_letter(i)}1"><is><t>{esc(h)}</t></is></c>'
+        for i, h in enumerate(headers)
+    )
+    sheet_rows.append(f'<row r="1">{header_cells}</row>')
+
+    row_num = 1
+    for row in rows:
+        row_num += 1
+        cells = ''.join(
+            f'<c t="inlineStr" r="{col_letter(i)}{row_num}"><is><t>{esc(v)}</t></is></c>'
+            for i, v in enumerate(row)
+        )
+        sheet_rows.append(f'<row r="{row_num}">{cells}</row>')
+
+    sheet_xml = (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+        '<sheetData>' + ''.join(sheet_rows) + '</sheetData></worksheet>'
+    )
+
+    content_types = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+    <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+    <Default Extension="xml" ContentType="application/xml"/>
+    <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+    <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>"""
+
+    rels = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"""
+
+    workbook = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>
+</workbook>"""
+
+    workbook_rels = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>"""
+
+    buffer = BytesIO()
+    with ZipFile(buffer, 'w', ZIP_DEFLATED) as zf:
+        zf.writestr('[Content_Types].xml', content_types)
+        zf.writestr('_rels/.rels', rels)
+        zf.writestr('xl/workbook.xml', workbook)
+        zf.writestr('xl/_rels/workbook.xml.rels', workbook_rels)
+        zf.writestr('xl/worksheets/sheet1.xml', sheet_xml)
+
+    return buffer.getvalue()


### PR DESCRIPTION
## Summary
- add helper to generate XLSX files without external dependencies
- update pauta and sorteio scripts to email only changes and attach XLSX outputs
- include XLSX attachment when sending full table of processes

## Testing
- `python -m py_compile sei_aneel/email_utils.py sei_aneel/pauta_aneel/pauta_aneel.py sei_aneel/sorteio_aneel/sorteio_aneel.py sei-aneel.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b5f68eb34832b86ecf567749ad724