### PR TITLE
Refine notification routing and attachments

### DIFF
--- a/sei_aneel/config/__init__.py
+++ b/sei_aneel/config/__init__.py
@@ -125,7 +125,13 @@ def load_config(path: str | Path | None = None) -> Dict[str, Any]:
     smtp.setdefault("port", 587)
     smtp.setdefault("starttls", False)
 
-    config.setdefault("email", {}).setdefault("recipients", [])
+    email_cfg = config.setdefault("email", {})
+    recipients = email_cfg.setdefault("recipients", {})
+    if isinstance(recipients, list):
+        # Backward compatibility: convert list to dict with all scripts enabled
+        email_cfg["recipients"] = {
+            addr: ["sei", "pauta", "sorteio"] for addr in recipients
+        }
 
     return config
 

--- a/sei_aneel/config/configs.example.json
+++ b/sei_aneel/config/configs.example.json
@@ -16,7 +16,9 @@
     "backup_folder_id": "ID_DA_PASTA_DO_DRIVE"
   },
   "email": {
-    "recipients": ["destinatario@exemplo.com"]
+    "recipients": {
+      "destinatario@exemplo.com": ["sei", "pauta", "sorteio"]
+    }
   },
   "paths": {
     "tesseract": "/usr/bin/tesseract",


### PR DESCRIPTION
## Summary
- Attach PDFs even when generation reports errors in pauta and sorteio modules
- Allow per-script email routing and update configuration/menu accordingly
- Fix SEI monitor to only notify on snapshot changes and include XLSX attachments

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f36548274832ba84068c2a824f377