### PR TITLE
Attach PDF and Excel results for ANEEL monitoring

### DIFF
--- a/sei_aneel/pauta_aneel/pauta_aneel.py
+++ b/sei_aneel/pauta_aneel/pauta_aneel.py
@@ -229,12 +229,20 @@ def gerar_pdf_da_pagina(url, pdf_file):
         env = os.environ.copy()
         env.setdefault("XDG_RUNTIME_DIR", "/tmp")
         result = subprocess.run(
-            ["wkhtmltopdf", "--quiet", "--load-error-handling", "ignore", url, pdf_file],
+            [
+                "wkhtmltopdf",
+                "--quiet",
+                "--print-media-type",
+                "--load-error-handling",
+                "ignore",
+                url,
+                pdf_file,
+            ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            env=env
+            env=env,
         )
-        if result.returncode != 0:
+        if result.returncode != 0 or not os.path.exists(pdf_file) or os.path.getsize(pdf_file) == 0:
             logger.error("Erro ao gerar PDF (wkhtmltopdf): %s", result.stderr.decode())
             registrar_log(f"Erro ao gerar PDF (wkhtmltopdf): {result.stderr.decode()}")
             return False


### PR DESCRIPTION
## Summary
- Fix PDF generation for pauta and sorteio scripts using page-print mode and integrity checks
- Add landscape PDF generation helper and attach PDF+XLSX in sei-aneel notifications and result emails

## Testing
- `python -m py_compile sei_aneel/pauta_aneel/pauta_aneel.py sei_aneel/sorteio_aneel/sorteio_aneel.py sei-aneel.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f3c2f4698832b9a2ea18fad9ce5e6