### PR TITLE
Ensure wkhtmltopdf is installed and improve PDF generation errors

### DIFF
--- a/sei-aneel.py
+++ b/sei-aneel.py
@@ -1570,7 +1570,9 @@ def gerar_pdf_html(html_content: str, logger) -> Optional[bytes]:
     """Gera PDF em orientação paisagem a partir de conteúdo HTML."""
     try:
         if not shutil.which("wkhtmltopdf"):
-            logger.warning("wkhtmltopdf não encontrado")
+            logger.warning(
+                "wkhtmltopdf não encontrado. Instale o pacote wkhtmltopdf para gerar PDFs."
+            )
             return None
         env = os.environ.copy()
         env.setdefault("XDG_RUNTIME_DIR", "/tmp")

--- a/sei-aneel.sh
+++ b/sei-aneel.sh
@@ -81,7 +81,7 @@ install_sei() {
   sudo chown -R "$ACTIVE_USER":"$ACTIVE_USER" "$SCRIPT_DIR"
 
   sudo apt-get update
-  sudo apt-get install -y python3 python3-pip tesseract-ocr chromium-browser chromium-chromedriver
+  sudo apt-get install -y python3 python3-pip tesseract-ocr chromium-browser chromium-chromedriver wkhtmltopdf
   sudo pip3 install --break-system-packages --ignore-installed --no-cache-dir -r "$SCRIPT_DIR/requirements.txt"
 
   STARTTLS=false
@@ -154,7 +154,7 @@ install_pauta() {
   sudo cp -r sei_aneel "$SCRIPT_DIR/" 2>/dev/null
 
   sudo apt-get update
-  sudo apt-get install -y python3 python3-pip
+  sudo apt-get install -y python3 python3-pip wkhtmltopdf
   sudo pip3 install --break-system-packages --ignore-installed --no-cache-dir -r "$PAUTA_DIR/requirements.txt"
 
 cat <<RUN > "$PAUTA_DIR/run.sh"
@@ -239,7 +239,7 @@ install_sorteio() {
   sudo cp -r sei_aneel "$SCRIPT_DIR/" 2>/dev/null
 
   sudo apt-get update
-  sudo apt-get install -y python3 python3-pip
+  sudo apt-get install -y python3 python3-pip wkhtmltopdf
   sudo pip3 install --break-system-packages --ignore-installed --no-cache-dir -r "$SORTEIO_DIR/requirements.txt"
 
 cat <<RUN > "$SORTEIO_DIR/run.sh"
@@ -319,7 +319,7 @@ select_install_menu() {
 
 install_dependencies_only() {
   sudo apt-get update
-  sudo apt-get install -y python3 python3-pip tesseract-ocr chromium-browser chromium-chromedriver
+  sudo apt-get install -y python3 python3-pip tesseract-ocr chromium-browser chromium-chromedriver wkhtmltopdf
   sudo pip3 install --break-system-packages --ignore-installed --no-cache-dir -r requirements.txt
   sudo mkdir -p "$CONFIG_DIR" "$LOG_DIR" "$PAUTA_DIR" "$PAUTA_LOG_DIR" "$SORTEIO_DIR" "$SORTEIO_LOG_DIR"
   sudo touch "$CONFIG_FILE"

--- a/sei_aneel/pauta_aneel/pauta_aneel.py
+++ b/sei_aneel/pauta_aneel/pauta_aneel.py
@@ -224,7 +224,9 @@ def extract_items_from_tr(url):
 def gerar_pdf_da_pagina(url, pdf_file):
     try:
         if not shutil.which("wkhtmltopdf"):
-            logger.error("wkhtmltopdf não encontrado")
+            msg = "wkhtmltopdf não encontrado. Instale o pacote wkhtmltopdf para gerar PDFs."
+            logger.error(msg)
+            registrar_log(msg)
             return False
         env = os.environ.copy()
         env.setdefault("XDG_RUNTIME_DIR", "/tmp")

--- a/sei_aneel/sorteio_aneel/sorteio_aneel.py
+++ b/sei_aneel/sorteio_aneel/sorteio_aneel.py
@@ -187,7 +187,9 @@ def extract_items_from_tr(url):
 def gerar_pdf_da_pagina(url, pdf_file):
     try:
         if not shutil.which("wkhtmltopdf"):
-            registrar_log("wkhtmltopdf não encontrado")
+            msg = "wkhtmltopdf não encontrado. Instale o pacote wkhtmltopdf para gerar PDFs."
+            logger.error(msg)
+            registrar_log(msg)
             return False
         env = os.environ.copy()
         env.setdefault("XDG_RUNTIME_DIR", "/tmp")

--- a/update_repo.sh
+++ b/update_repo.sh
@@ -88,7 +88,7 @@ fi
 
 # instala dependências do sistema e python
 sudo apt-get update
-sudo apt-get install -y python3 python3-pip tesseract-ocr chromium-browser chromium-chromedriver
+sudo apt-get install -y python3 python3-pip tesseract-ocr chromium-browser chromium-chromedriver wkhtmltopdf
 sudo pip3 install --break-system-packages --ignore-installed -r "$TARGET_DIR/requirements.txt"
 
 # instala/atualiza módulos adicionais


### PR DESCRIPTION
## Summary
- Improve PDF generation functions by logging a clear message when wkhtmltopdf is missing
- Install wkhtmltopdf in setup scripts so PDF creation works out of the box

## Testing
- `python3 -m py_compile sei-aneel.py sei_aneel/pauta_aneel/pauta_aneel.py sei_aneel/sorteio_aneel/sorteio_aneel.py`
- `bash -n sei-aneel.sh update_repo.sh`


------
https://chatgpt.com/codex/tasks/task_e_689f62cc2940832b9249234640f0f48a